### PR TITLE
feat: Add H2 database integration with Spring Data JPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,100 @@
 # Java_spbstu
 Репозиторий для публикации решений домашних задач по дисциплине "Приёмы программирования на языке Java" студента гр. 5130203/20102 Даниила Середы
 
-## Step 2: Unit Tests
+##  Реализованные Steps
 
-Добавлены unit-тесты для всех компонентов приложения:
+<details>
+<summary><b>Step 1: Basic REST API with In-Memory Storage</b></summary>
 
-### Service Layer Tests
+###  Цель
+Создание базового REST API с хранением данных в памяти
+
+###  Реализовано
+- **REST Controllers**: TaskApiController, UserApiController, NotificationApiController
+- **Service Layer**: TaskManagementService, UserManagementService, NotificationManagementService  
+- **In-Memory Storage**: MemoryTaskRepository, MemoryUserRepository, MemoryNotificationRepository
+- **Domain Models**: TaskEntity, UserEntity, NotificationEntity с Lombok
+- **Exception Handling**: EntityNotFoundException, EntityAlreadyExistsException
+- **HTTP Endpoints**: GET, POST, DELETE с правильными статус-кодами
+
+###  Технологии
+- Spring Boot 3.4.5
+- Lombok для упрощения кода
+- HashMap для хранения данных
+- REST API архитектура
+
+</details>
+
+<details>
+<summary><b>Step 2: Write unit-tests</b></summary>
+
+### Цель
+Покрытие всего приложения unit-тестами
+
+###  Реализовано
+**unit-тесты** для всех компонентов:
+
+#### Service Layer Tests
 - **TaskManagementServiceTest** - тестирование бизнес-логики управления задачами
 - **UserManagementServiceTest** - тестирование логики пользователей и валидации
 - **NotificationManagementServiceTest** - тестирование системы уведомлений
 
-### Repository Layer Tests
+#### Repository Layer Tests
 - **MemoryTaskRepositoryTest** - тестирование in-memory хранилища задач
 - **MemoryUserRepositoryTest** - тестирование in-memory хранилища пользователей
 - **MemoryNotificationRepositoryTest** - тестирование in-memory хранилища уведомлений
 
-### Domain Model Tests
+#### Domain Model Tests
 - **TaskEntityTest** - тестирование модели задач (Builder pattern, equals/hashCode)
 - **UserEntityTest** - тестирование модели пользователей
 - **NotificationEntityTest** - тестирование модели уведомлений
 
-### Exception Tests
+#### Exception Tests
 - **EntityNotFoundExceptionTest** - тестирование исключений "сущность не найдена"
 - **EntityAlreadyExistsExceptionTest** - тестирование исключений "сущность уже существует"
+
+###  Технологии
+- JUnit 5
+- Mockito для мокирования
+- Spring Test Context
+- AAA Pattern (Arrange-Act-Assert)
+
+</details>
+
+<details>
+<summary><b>Step 3: In-Memory Database (H2)</b></summary>
+
+###  Цель
+Интеграция H2 database с Spring Data JPA
+
+###  Реализовано
+- **H2 Database**: In-memory база данных с консолью
+- **Spring Data JPA**: Полная интеграция с JPA/Hibernate
+- **Entity Mapping**: JPA аннотации (@Entity, @Id, @GeneratedValue, @Table)
+- **JPA Repositories**: TaskJpaRepository, UserJpaRepository, NotificationJpaRepository
+- **Profile Architecture**: 
+  - `inmemory` - для Step 1-2 (HashMap storage)
+  - `h2` - для Step 3 (JPA + H2 database)
+- **Обратная совместимость**: Все предыдущие функции сохранены
+
+###  Архитектура
+- **JPA Entity классы**: TaskEntity, UserEntity, NotificationEntity
+- **Repository интерфейсы**: TaskDataRepository, UserDataRepository, NotificationDataRepository
+- **Memory реализации**: MemoryTaskRepository, MemoryUserRepository, MemoryNotificationRepository
+- **JPA реализации**: JpaTaskRepository, JpaUserRepository, JpaNotificationRepository
+
+###  Технологии
+- Spring Data JPA
+- H2 Database
+- Hibernate ORM
+- Spring Profiles
+- JPA/Hibernate аннотации
+
+###  Результат
+- **36 Java файлов** (включая тесты)
+- **11 тестовых файлов**
+- **Все тесты проходят** ✅
+- **H2 консоль доступна** по адресу `/h2-console`
+
+</details>
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'com.h2database:h2'
 	implementation 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	

--- a/src/main/java/org/example/taskmanager/domain/NotificationEntity.java
+++ b/src/main/java/org/example/taskmanager/domain/NotificationEntity.java
@@ -2,6 +2,11 @@ package org.example.taskmanager.domain;
 
 import java.time.LocalDateTime;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -9,12 +14,16 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
+@Entity
+@Table(name = "notifications")
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode
 public class NotificationEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @NonNull

--- a/src/main/java/org/example/taskmanager/domain/TaskEntity.java
+++ b/src/main/java/org/example/taskmanager/domain/TaskEntity.java
@@ -2,6 +2,11 @@ package org.example.taskmanager.domain;
 
 import java.time.LocalDateTime;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -9,12 +14,16 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
+@Entity
+@Table(name = "tasks")
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode
 public class TaskEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     
     @NonNull

--- a/src/main/java/org/example/taskmanager/domain/UserEntity.java
+++ b/src/main/java/org/example/taskmanager/domain/UserEntity.java
@@ -1,5 +1,10 @@
 package org.example.taskmanager.domain;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -7,12 +12,16 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
+@Entity
+@Table(name = "users")
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode
 public class UserEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     
     @NonNull

--- a/src/main/java/org/example/taskmanager/repository/NotificationDataRepository.java
+++ b/src/main/java/org/example/taskmanager/repository/NotificationDataRepository.java
@@ -1,12 +1,11 @@
 package org.example.taskmanager.repository;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.example.taskmanager.domain.NotificationEntity;
 
 public interface NotificationDataRepository {
-    Optional<NotificationEntity> findById(Long notificationId);
-    List<NotificationEntity> findAllByRecipientOrderByTimestampDesc(Long recipientId);
-    List<NotificationEntity> findUnviewedByRecipientOrderByTimestampDesc(Long recipientId);
+    List<NotificationEntity> findAllByRecipientId(Long recipientId);
+    List<NotificationEntity> findPendingNotificationsByRecipientId(Long recipientId);
+    List<NotificationEntity> findByRelatedTaskId(Long relatedTaskId);
 }

--- a/src/main/java/org/example/taskmanager/repository/TaskDataRepository.java
+++ b/src/main/java/org/example/taskmanager/repository/TaskDataRepository.java
@@ -6,8 +6,9 @@ import java.util.Optional;
 import org.example.taskmanager.domain.TaskEntity;
 
 public interface TaskDataRepository {
-    List<TaskEntity> findAllByOwnerAndNotRemoved(Long ownerId);
-    List<TaskEntity> findPendingByOwnerAndNotRemoved(Long ownerId);
-    Optional<TaskEntity> findByIdAndNotRemoved(Long id);
-    TaskEntity store(TaskEntity task);
+    List<TaskEntity> findAllByOwnerId(Long ownerId);
+    List<TaskEntity> findPendingTasksByOwnerId(Long ownerId);
+    Optional<TaskEntity> findByIdAndOwnerId(Long id, Long ownerId);
+    TaskEntity save(TaskEntity task);
+    void deleteById(Long id);
 }

--- a/src/main/java/org/example/taskmanager/repository/UserDataRepository.java
+++ b/src/main/java/org/example/taskmanager/repository/UserDataRepository.java
@@ -5,8 +5,9 @@ import java.util.Optional;
 import org.example.taskmanager.domain.UserEntity;
 
 public interface UserDataRepository {
-    UserEntity store(UserEntity user);
+    UserEntity save(UserEntity user);
     Optional<UserEntity> findByLogin(String login);
-    boolean checkLoginExists(String login);
-    boolean checkEmailExists(String email);
+    Optional<UserEntity> findByEmailAddress(String emailAddress);
+    boolean existsByLogin(String login);
+    boolean existsByEmailAddress(String emailAddress);
 }

--- a/src/main/java/org/example/taskmanager/repository/jpa/NotificationJpaRepository.java
+++ b/src/main/java/org/example/taskmanager/repository/jpa/NotificationJpaRepository.java
@@ -1,0 +1,29 @@
+package org.example.taskmanager.repository.jpa;
+
+import java.util.List;
+
+import org.example.taskmanager.domain.NotificationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationJpaRepository extends JpaRepository<NotificationEntity, Long> {
+    
+    /**
+     * Find all notifications by recipient ID
+     */
+    List<NotificationEntity> findByRecipientId(Long recipientId);
+    
+    /**
+     * Find all pending notifications by recipient ID (not viewed)
+     */
+    @Query("SELECT n FROM NotificationEntity n WHERE n.recipientId = :recipientId AND n.viewed = false")
+    List<NotificationEntity> findPendingNotificationsByRecipientId(@Param("recipientId") Long recipientId);
+    
+    /**
+     * Find notifications by related task ID
+     */
+    List<NotificationEntity> findByRelatedTaskId(Long relatedTaskId);
+}

--- a/src/main/java/org/example/taskmanager/repository/jpa/TaskJpaRepository.java
+++ b/src/main/java/org/example/taskmanager/repository/jpa/TaskJpaRepository.java
@@ -1,0 +1,32 @@
+package org.example.taskmanager.repository.jpa;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.example.taskmanager.domain.TaskEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TaskJpaRepository extends JpaRepository<TaskEntity, Long> {
+    
+    /**
+     * Find all tasks by owner ID that are not removed
+     */
+    @Query("SELECT t FROM TaskEntity t WHERE t.ownerId = :ownerId AND t.removed = false")
+    List<TaskEntity> findByOwnerIdAndNotRemoved(@Param("ownerId") Long ownerId);
+    
+    /**
+     * Find all pending tasks by owner ID (not finished and not removed)
+     */
+    @Query("SELECT t FROM TaskEntity t WHERE t.ownerId = :ownerId AND t.finished = false AND t.removed = false")
+    List<TaskEntity> findPendingTasksByOwnerId(@Param("ownerId") Long ownerId);
+    
+    /**
+     * Find task by ID and owner ID (for security)
+     */
+    @Query("SELECT t FROM TaskEntity t WHERE t.id = :id AND t.ownerId = :ownerId")
+    Optional<TaskEntity> findByIdAndOwnerId(@Param("id") Long id, @Param("ownerId") Long ownerId);
+}

--- a/src/main/java/org/example/taskmanager/repository/jpa/UserJpaRepository.java
+++ b/src/main/java/org/example/taskmanager/repository/jpa/UserJpaRepository.java
@@ -1,0 +1,31 @@
+package org.example.taskmanager.repository.jpa;
+
+import java.util.Optional;
+
+import org.example.taskmanager.domain.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
+    
+    /**
+     * Find user by login (for authentication)
+     */
+    Optional<UserEntity> findByLogin(String login);
+    
+    /**
+     * Find user by email address
+     */
+    Optional<UserEntity> findByEmailAddress(String emailAddress);
+    
+    /**
+     * Check if user exists by login
+     */
+    boolean existsByLogin(String login);
+    
+    /**
+     * Check if user exists by email address
+     */
+    boolean existsByEmailAddress(String emailAddress);
+}

--- a/src/main/java/org/example/taskmanager/repository/jpa/impl/JpaNotificationRepository.java
+++ b/src/main/java/org/example/taskmanager/repository/jpa/impl/JpaNotificationRepository.java
@@ -1,0 +1,35 @@
+package org.example.taskmanager.repository.jpa.impl;
+
+import java.util.List;
+
+import org.example.taskmanager.domain.NotificationEntity;
+import org.example.taskmanager.repository.NotificationDataRepository;
+import org.example.taskmanager.repository.jpa.NotificationJpaRepository;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Profile("h2")
+public class JpaNotificationRepository implements NotificationDataRepository {
+    
+    private final NotificationJpaRepository jpaRepository;
+    
+    public JpaNotificationRepository(NotificationJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+    
+    @Override
+    public List<NotificationEntity> findAllByRecipientId(Long recipientId) {
+        return jpaRepository.findByRecipientId(recipientId);
+    }
+    
+    @Override
+    public List<NotificationEntity> findPendingNotificationsByRecipientId(Long recipientId) {
+        return jpaRepository.findPendingNotificationsByRecipientId(recipientId);
+    }
+    
+    @Override
+    public List<NotificationEntity> findByRelatedTaskId(Long relatedTaskId) {
+        return jpaRepository.findByRelatedTaskId(relatedTaskId);
+    }
+}

--- a/src/main/java/org/example/taskmanager/repository/jpa/impl/JpaTaskRepository.java
+++ b/src/main/java/org/example/taskmanager/repository/jpa/impl/JpaTaskRepository.java
@@ -1,0 +1,46 @@
+package org.example.taskmanager.repository.jpa.impl;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.example.taskmanager.domain.TaskEntity;
+import org.example.taskmanager.repository.TaskDataRepository;
+import org.example.taskmanager.repository.jpa.TaskJpaRepository;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Profile("h2")
+public class JpaTaskRepository implements TaskDataRepository {
+    
+    private final TaskJpaRepository jpaRepository;
+    
+    public JpaTaskRepository(TaskJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+    
+    @Override
+    public List<TaskEntity> findAllByOwnerId(Long ownerId) {
+        return jpaRepository.findByOwnerIdAndNotRemoved(ownerId);
+    }
+    
+    @Override
+    public List<TaskEntity> findPendingTasksByOwnerId(Long ownerId) {
+        return jpaRepository.findPendingTasksByOwnerId(ownerId);
+    }
+    
+    @Override
+    public Optional<TaskEntity> findByIdAndOwnerId(Long id, Long ownerId) {
+        return jpaRepository.findByIdAndOwnerId(id, ownerId);
+    }
+    
+    @Override
+    public TaskEntity save(TaskEntity task) {
+        return jpaRepository.save(task);
+    }
+    
+    @Override
+    public void deleteById(Long id) {
+        jpaRepository.deleteById(id);
+    }
+}

--- a/src/main/java/org/example/taskmanager/repository/jpa/impl/JpaUserRepository.java
+++ b/src/main/java/org/example/taskmanager/repository/jpa/impl/JpaUserRepository.java
@@ -1,0 +1,45 @@
+package org.example.taskmanager.repository.jpa.impl;
+
+import java.util.Optional;
+
+import org.example.taskmanager.domain.UserEntity;
+import org.example.taskmanager.repository.UserDataRepository;
+import org.example.taskmanager.repository.jpa.UserJpaRepository;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Profile("h2")
+public class JpaUserRepository implements UserDataRepository {
+    
+    private final UserJpaRepository jpaRepository;
+    
+    public JpaUserRepository(UserJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+    
+    @Override
+    public Optional<UserEntity> findByLogin(String login) {
+        return jpaRepository.findByLogin(login);
+    }
+    
+    @Override
+    public Optional<UserEntity> findByEmailAddress(String emailAddress) {
+        return jpaRepository.findByEmailAddress(emailAddress);
+    }
+    
+    @Override
+    public boolean existsByLogin(String login) {
+        return jpaRepository.existsByLogin(login);
+    }
+    
+    @Override
+    public boolean existsByEmailAddress(String emailAddress) {
+        return jpaRepository.existsByEmailAddress(emailAddress);
+    }
+    
+    @Override
+    public UserEntity save(UserEntity user) {
+        return jpaRepository.save(user);
+    }
+}

--- a/src/main/java/org/example/taskmanager/repository/memory/MemoryNotificationRepository.java
+++ b/src/main/java/org/example/taskmanager/repository/memory/MemoryNotificationRepository.java
@@ -1,13 +1,16 @@
 package org.example.taskmanager.repository.memory;
 
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Repository;
-import org.example.taskmanager.domain.NotificationEntity;
-import org.example.taskmanager.repository.NotificationDataRepository;
-
-import java.util.*;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+
+import org.example.taskmanager.domain.NotificationEntity;
+import org.example.taskmanager.repository.NotificationDataRepository;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @Profile("inmemory")
@@ -16,12 +19,7 @@ public class MemoryNotificationRepository implements NotificationDataRepository 
     private final AtomicLong idGenerator = new AtomicLong(1);
 
     @Override
-    public Optional<NotificationEntity> findById(Long notificationId) {
-        return Optional.ofNullable(storage.get(notificationId));
-    }
-
-    @Override
-    public List<NotificationEntity> findAllByRecipientOrderByTimestampDesc(Long recipientId) {
+    public List<NotificationEntity> findAllByRecipientId(Long recipientId) {
         return storage.values().stream()
                 .filter(notification -> notification.getRecipientId().equals(recipientId))
                 .sorted(Comparator.comparing(NotificationEntity::getTimestamp).reversed())
@@ -29,11 +27,18 @@ public class MemoryNotificationRepository implements NotificationDataRepository 
     }
 
     @Override
-    public List<NotificationEntity> findUnviewedByRecipientOrderByTimestampDesc(Long recipientId) {
+    public List<NotificationEntity> findPendingNotificationsByRecipientId(Long recipientId) {
         return storage.values().stream()
                 .filter(notification -> notification.getRecipientId().equals(recipientId) 
                     && !notification.getViewed())
                 .sorted(Comparator.comparing(NotificationEntity::getTimestamp).reversed())
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<NotificationEntity> findByRelatedTaskId(Long relatedTaskId) {
+        return storage.values().stream()
+                .filter(notification -> notification.getRelatedTaskId().equals(relatedTaskId))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/example/taskmanager/repository/memory/MemoryTaskRepository.java
+++ b/src/main/java/org/example/taskmanager/repository/memory/MemoryTaskRepository.java
@@ -1,13 +1,16 @@
 package org.example.taskmanager.repository.memory;
 
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Repository;
-import org.example.taskmanager.domain.TaskEntity;
-import org.example.taskmanager.repository.TaskDataRepository;
-
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+
+import org.example.taskmanager.domain.TaskEntity;
+import org.example.taskmanager.repository.TaskDataRepository;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @Profile("inmemory")
@@ -16,14 +19,14 @@ public class MemoryTaskRepository implements TaskDataRepository {
     private final AtomicLong idGenerator = new AtomicLong(1);
 
     @Override
-    public List<TaskEntity> findAllByOwnerAndNotRemoved(Long ownerId) {
+    public List<TaskEntity> findAllByOwnerId(Long ownerId) {
         return storage.values().stream()
                 .filter(task -> task.getOwnerId().equals(ownerId) && !task.getRemoved())
                 .collect(Collectors.toList());
     }
 
     @Override
-    public List<TaskEntity> findPendingByOwnerAndNotRemoved(Long ownerId) {
+    public List<TaskEntity> findPendingTasksByOwnerId(Long ownerId) {
         return storage.values().stream()
                 .filter(task -> task.getOwnerId().equals(ownerId) 
                     && !task.getFinished() 
@@ -32,20 +35,25 @@ public class MemoryTaskRepository implements TaskDataRepository {
     }
 
     @Override
-    public Optional<TaskEntity> findByIdAndNotRemoved(Long id) {
+    public Optional<TaskEntity> findByIdAndOwnerId(Long id, Long ownerId) {
         TaskEntity task = storage.get(id);
-        if (task != null && !task.getRemoved()) {
+        if (task != null && !task.getRemoved() && task.getOwnerId().equals(ownerId)) {
             return Optional.of(task);
         }
         return Optional.empty();
     }
 
     @Override
-    public TaskEntity store(TaskEntity task) {
+    public TaskEntity save(TaskEntity task) {
         if (task.getId() == null) {
             task.setId(idGenerator.getAndIncrement());
         }
         storage.put(task.getId(), task);
         return task;
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        storage.remove(id);
     }
 }

--- a/src/main/java/org/example/taskmanager/repository/memory/MemoryUserRepository.java
+++ b/src/main/java/org/example/taskmanager/repository/memory/MemoryUserRepository.java
@@ -1,12 +1,14 @@
 package org.example.taskmanager.repository.memory;
 
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Repository;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.example.taskmanager.domain.UserEntity;
 import org.example.taskmanager.repository.UserDataRepository;
-
-import java.util.*;
-import java.util.concurrent.atomic.AtomicLong;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @Profile("inmemory")
@@ -15,7 +17,7 @@ public class MemoryUserRepository implements UserDataRepository {
     private final AtomicLong idGenerator = new AtomicLong(1);
 
     @Override
-    public UserEntity store(UserEntity user) {
+    public UserEntity save(UserEntity user) {
         if (user.getId() == null) {
             user.setId(idGenerator.getAndIncrement());
         }
@@ -31,14 +33,21 @@ public class MemoryUserRepository implements UserDataRepository {
     }
 
     @Override
-    public boolean checkLoginExists(String login) {
+    public Optional<UserEntity> findByEmailAddress(String emailAddress) {
+        return storage.values().stream()
+                .filter(user -> user.getEmailAddress().equals(emailAddress))
+                .findFirst();
+    }
+
+    @Override
+    public boolean existsByLogin(String login) {
         return storage.values().stream()
                 .anyMatch(user -> user.getLogin().equals(login));
     }
 
     @Override
-    public boolean checkEmailExists(String email) {
+    public boolean existsByEmailAddress(String emailAddress) {
         return storage.values().stream()
-                .anyMatch(user -> user.getEmailAddress().equals(email));
+                .anyMatch(user -> user.getEmailAddress().equals(emailAddress));
     }
 }

--- a/src/main/java/org/example/taskmanager/service/NotificationManagementService.java
+++ b/src/main/java/org/example/taskmanager/service/NotificationManagementService.java
@@ -15,16 +15,11 @@ public class NotificationManagementService {
     private final NotificationDataRepository notificationRepository;
 
     public List<NotificationEntity> getAllUserNotifications(Long recipientId) {
-        return notificationRepository.findAllByRecipientOrderByTimestampDesc(recipientId);
+        return notificationRepository.findAllByRecipientId(recipientId);
     }
 
     public List<NotificationEntity> getUnreadNotifications(Long recipientId) {
-        return notificationRepository.findUnviewedByRecipientOrderByTimestampDesc(recipientId);
-    }
-
-    public NotificationEntity getNotificationDetails(Long notificationId) {
-        return notificationRepository.findById(notificationId)
-                .orElseThrow(() -> new EntityNotFoundException("Notification with id " + notificationId + " not found"));
+        return notificationRepository.findPendingNotificationsByRecipientId(recipientId);
     }
 
     private void performNotificationValidation(NotificationEntity notification) {

--- a/src/main/java/org/example/taskmanager/service/TaskManagementService.java
+++ b/src/main/java/org/example/taskmanager/service/TaskManagementService.java
@@ -1,13 +1,14 @@
 package org.example.taskmanager.service;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.example.taskmanager.exception.EntityNotFoundException;
-import org.example.taskmanager.domain.TaskEntity;
-import org.example.taskmanager.repository.TaskDataRepository;
-
 import java.time.LocalDateTime;
 import java.util.List;
+
+import org.example.taskmanager.domain.TaskEntity;
+import org.example.taskmanager.exception.EntityNotFoundException;
+import org.example.taskmanager.repository.TaskDataRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -16,29 +17,29 @@ public class TaskManagementService {
     private final TaskDataRepository taskRepository;
 
     public List<TaskEntity> getAllUserTasks(Long ownerId) {
-        return taskRepository.findAllByOwnerAndNotRemoved(ownerId);
+        return taskRepository.findAllByOwnerId(ownerId);
     }
 
     public List<TaskEntity> getActiveTasks(Long ownerId) {
-        return taskRepository.findPendingByOwnerAndNotRemoved(ownerId);
+        return taskRepository.findPendingTasksByOwnerId(ownerId);
     }
 
-    public TaskEntity getTaskDetails(Long taskId) {
-        return taskRepository.findByIdAndNotRemoved(taskId)
+    public TaskEntity getTaskDetails(Long taskId, Long ownerId) {
+        return taskRepository.findByIdAndOwnerId(taskId, ownerId)
                 .orElseThrow(() -> new EntityNotFoundException("Task with id " + taskId + " not found"));
     }
 
     public TaskEntity addNewTask(TaskEntity task) {
         performTaskValidation(task);
         task.setCreateTime(LocalDateTime.now());
-        return taskRepository.store(task);
+        return taskRepository.save(task);
     }
 
-    public void removeTask(Long taskId) {
-        TaskEntity task = taskRepository.findByIdAndNotRemoved(taskId)
+    public void removeTask(Long taskId, Long ownerId) {
+        TaskEntity task = taskRepository.findByIdAndOwnerId(taskId, ownerId)
                 .orElseThrow(() -> new EntityNotFoundException("Task with id " + taskId + " not found"));
         task.setRemoved(true);
-        taskRepository.store(task);
+        taskRepository.save(task);
     }
 
     private void performTaskValidation(TaskEntity task) {

--- a/src/main/java/org/example/taskmanager/service/UserManagementService.java
+++ b/src/main/java/org/example/taskmanager/service/UserManagementService.java
@@ -1,12 +1,13 @@
 package org.example.taskmanager.service;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.example.taskmanager.exception.EntityNotFoundException;
-import org.example.taskmanager.domain.UserEntity;
-import org.example.taskmanager.repository.UserDataRepository;
-
 import java.util.regex.Pattern;
+
+import org.example.taskmanager.domain.UserEntity;
+import org.example.taskmanager.exception.EntityNotFoundException;
+import org.example.taskmanager.repository.UserDataRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -20,7 +21,7 @@ public class UserManagementService {
         verifyLoginUniqueness(user.getLogin());
         verifyEmailUniqueness(user.getEmailAddress());
 
-        return userRepository.store(user);
+        return userRepository.save(user);
     }
 
     public UserEntity authenticateUser(String login, String password) {
@@ -55,13 +56,13 @@ public class UserManagementService {
     }
 
     private void verifyLoginUniqueness(String login) {
-        if (userRepository.checkLoginExists(login)) {
+        if (userRepository.existsByLogin(login)) {
             throw new IllegalArgumentException("Login already exists");
         }
     }
 
     private void verifyEmailUniqueness(String email) {
-        if (userRepository.checkEmailExists(email)) {
+        if (userRepository.existsByEmailAddress(email)) {
             throw new IllegalArgumentException("Email already exists");
         }
     }

--- a/src/main/java/org/example/taskmanager/web/TaskApiController.java
+++ b/src/main/java/org/example/taskmanager/web/TaskApiController.java
@@ -41,9 +41,9 @@ public class TaskApiController {
         return ResponseEntity.ok(taskService.addNewTask(task));
     }
 
-    @DeleteMapping("/{taskId}")
-    public ResponseEntity<Void> removeTask(@PathVariable Long taskId) {
-        taskService.removeTask(taskId);
+    @DeleteMapping("/{taskId}/user/{ownerId}")
+    public ResponseEntity<Void> removeTask(@PathVariable Long taskId, @PathVariable Long ownerId) {
+        taskService.removeTask(taskId, ownerId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/test/java/org/example/taskmanager/repository/memory/MemoryNotificationRepositoryTest.java
+++ b/src/test/java/org/example/taskmanager/repository/memory/MemoryNotificationRepositoryTest.java
@@ -1,55 +1,93 @@
 package org.example.taskmanager.repository.memory;
 
+import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import org.example.taskmanager.domain.NotificationEntity;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("inmemory")
 class MemoryNotificationRepositoryTest {
 
-    @Test
-    void testFindAllByRecipientOrderByTimestampDesc_EmptyResult() {
-        // Given
-        MemoryNotificationRepository repository = new MemoryNotificationRepository();
-        Long recipientId = 1L;
+    private MemoryNotificationRepository repository;
+    private NotificationEntity notification1;
+    private NotificationEntity notification2;
+    private NotificationEntity notification3;
 
+    @BeforeEach
+    void setUp() {
+        repository = new MemoryNotificationRepository();
+        
+        notification1 = NotificationEntity.builder()
+                .id(1L)
+                .message("Test notification 1")
+                .timestamp(LocalDateTime.now())
+                .relatedTaskId(1L)
+                .recipientId(1L)
+                .viewed(false)
+                .build();
+                
+        notification2 = NotificationEntity.builder()
+                .id(2L)
+                .message("Test notification 2")
+                .timestamp(LocalDateTime.now())
+                .relatedTaskId(2L)
+                .recipientId(1L)
+                .viewed(true)
+                .build();
+                
+        notification3 = NotificationEntity.builder()
+                .id(3L)
+                .message("Test notification 3")
+                .timestamp(LocalDateTime.now())
+                .relatedTaskId(3L)
+                .recipientId(2L)
+                .viewed(false)
+                .build();
+    }
+
+    @Test
+    void testFindAllByRecipientId_Success() {
+        // Given
+        Long recipientId = 1L;
+        
         // When
-        List<NotificationEntity> result = repository.findAllByRecipientOrderByTimestampDesc(recipientId);
+        List<NotificationEntity> result = repository.findAllByRecipientId(recipientId);
 
         // Then
+        assertNotNull(result);
         assertTrue(result.isEmpty());
     }
 
     @Test
-    void testFindUnviewedByRecipientOrderByTimestampDesc_EmptyResult() {
+    void testFindPendingNotificationsByRecipientId_Success() {
         // Given
-        MemoryNotificationRepository repository = new MemoryNotificationRepository();
         Long recipientId = 1L;
-
+        
         // When
-        List<NotificationEntity> result = repository.findUnviewedByRecipientOrderByTimestampDesc(recipientId);
+        List<NotificationEntity> result = repository.findPendingNotificationsByRecipientId(recipientId);
 
         // Then
+        assertNotNull(result);
         assertTrue(result.isEmpty());
     }
 
     @Test
-    void testFindById_NotFound() {
+    void testFindByRelatedTaskId_Success() {
         // Given
-        MemoryNotificationRepository repository = new MemoryNotificationRepository();
-
+        Long relatedTaskId = 1L;
+        
         // When
-        Optional<NotificationEntity> result = repository.findById(999L);
+        List<NotificationEntity> result = repository.findByRelatedTaskId(relatedTaskId);
 
         // Then
-        assertFalse(result.isPresent());
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
     }
 
     @Test
@@ -62,134 +100,158 @@ class MemoryNotificationRepositoryTest {
     }
 
     @Test
-    void testRepositoryProfile() {
+    void testFindAllByRecipientId_EmptyResult() {
         // Given
-        MemoryNotificationRepository repository = new MemoryNotificationRepository();
-
-        // When & Then
-        // Test that repository can be instantiated without errors
-        assertNotNull(repository);
-        
-        // Test that methods can be called without errors
-        List<NotificationEntity> allNotifications = repository.findAllByRecipientOrderByTimestampDesc(1L);
-        List<NotificationEntity> unreadNotifications = repository.findUnviewedByRecipientOrderByTimestampDesc(1L);
-        Optional<NotificationEntity> notification = repository.findById(1L);
-        
-        assertNotNull(allNotifications);
-        assertNotNull(unreadNotifications);
-        assertNotNull(notification);
-    }
-
-    @Test
-    void testRepositoryMethodsReturnCorrectTypes() {
-        // Given
-        MemoryNotificationRepository repository = new MemoryNotificationRepository();
+        Long nonExistentRecipientId = 999L;
 
         // When
-        List<NotificationEntity> allNotifications = repository.findAllByRecipientOrderByTimestampDesc(1L);
-        List<NotificationEntity> unreadNotifications = repository.findUnviewedByRecipientOrderByTimestampDesc(1L);
-        Optional<NotificationEntity> notification = repository.findById(1L);
+        List<NotificationEntity> result = repository.findAllByRecipientId(nonExistentRecipientId);
 
         // Then
-        assertTrue(allNotifications instanceof List);
-        assertTrue(unreadNotifications instanceof List);
-        assertTrue(notification instanceof Optional);
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
     }
 
     @Test
-    void testRepositoryHandlesNullRecipientId() {
+    void testFindPendingNotificationsByRecipientId_EmptyResult() {
         // Given
-        MemoryNotificationRepository repository = new MemoryNotificationRepository();
-
-        // When & Then
-        // Should not throw exception, but return empty results
-        assertDoesNotThrow(() -> {
-            List<NotificationEntity> result = repository.findAllByRecipientOrderByTimestampDesc(null);
-            assertTrue(result.isEmpty());
-        });
-
-        assertDoesNotThrow(() -> {
-            List<NotificationEntity> result = repository.findUnviewedByRecipientOrderByTimestampDesc(null);
-            assertTrue(result.isEmpty());
-        });
-    }
-
-    @Test
-    void testRepositoryHandlesNullNotificationId() {
-        // Given
-        MemoryNotificationRepository repository = new MemoryNotificationRepository();
+        Long nonExistentRecipientId = 999L;
 
         // When
-        Optional<NotificationEntity> result = repository.findById(null);
+        List<NotificationEntity> result = repository.findPendingNotificationsByRecipientId(nonExistentRecipientId);
 
         // Then
-        assertFalse(result.isPresent());
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
     }
 
     @Test
-    void testRepositoryHandlesNegativeIds() {
+    void testFindByRelatedTaskId_EmptyResult() {
         // Given
-        MemoryNotificationRepository repository = new MemoryNotificationRepository();
+        Long nonExistentTaskId = 999L;
 
+        // When
+        List<NotificationEntity> result = repository.findByRelatedTaskId(nonExistentTaskId);
+
+        // Then
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testFindAllByRecipientId_NullInput() {
         // When & Then
         assertDoesNotThrow(() -> {
-            List<NotificationEntity> result = repository.findAllByRecipientOrderByTimestampDesc(-1L);
-            assertTrue(result.isEmpty());
-        });
-
-        assertDoesNotThrow(() -> {
-            List<NotificationEntity> result = repository.findUnviewedByRecipientOrderByTimestampDesc(-1L);
-            assertTrue(result.isEmpty());
-        });
-
-        assertDoesNotThrow(() -> {
-            Optional<NotificationEntity> result = repository.findById(-1L);
-            assertFalse(result.isPresent());
+            List<NotificationEntity> result = repository.findAllByRecipientId(null);
+            assertNotNull(result);
         });
     }
 
     @Test
-    void testRepositoryHandlesZeroIds() {
-        // Given
-        MemoryNotificationRepository repository = new MemoryNotificationRepository();
-
+    void testFindPendingNotificationsByRecipientId_NullInput() {
         // When & Then
         assertDoesNotThrow(() -> {
-            List<NotificationEntity> result = repository.findAllByRecipientOrderByTimestampDesc(0L);
-            assertTrue(result.isEmpty());
-        });
-
-        assertDoesNotThrow(() -> {
-            List<NotificationEntity> result = repository.findUnviewedByRecipientOrderByTimestampDesc(0L);
-            assertTrue(result.isEmpty());
-        });
-
-        assertDoesNotThrow(() -> {
-            Optional<NotificationEntity> result = repository.findById(0L);
-            assertFalse(result.isPresent());
+            List<NotificationEntity> result = repository.findPendingNotificationsByRecipientId(null);
+            assertNotNull(result);
         });
     }
 
     @Test
-    void testRepositoryHandlesLargeIds() {
+    void testFindByRelatedTaskId_NullInput() {
+        // When & Then
+        assertDoesNotThrow(() -> {
+            List<NotificationEntity> result = repository.findByRelatedTaskId(null);
+            assertNotNull(result);
+        });
+    }
+
+    @Test
+    void testFindAllByRecipientId_NegativeId() {
+        // When & Then
+        assertDoesNotThrow(() -> {
+            List<NotificationEntity> result = repository.findAllByRecipientId(-1L);
+            assertNotNull(result);
+        });
+    }
+
+    @Test
+    void testFindPendingNotificationsByRecipientId_NegativeId() {
+        // When & Then
+        assertDoesNotThrow(() -> {
+            List<NotificationEntity> result = repository.findPendingNotificationsByRecipientId(-1L);
+            assertNotNull(result);
+        });
+    }
+
+    @Test
+    void testFindByRelatedTaskId_NegativeId() {
+        // When & Then
+        assertDoesNotThrow(() -> {
+            List<NotificationEntity> result = repository.findByRelatedTaskId(-1L);
+            assertNotNull(result);
+        });
+    }
+
+    @Test
+    void testFindAllByRecipientId_ZeroId() {
+        // When & Then
+        assertDoesNotThrow(() -> {
+            List<NotificationEntity> result = repository.findAllByRecipientId(0L);
+            assertNotNull(result);
+        });
+    }
+
+    @Test
+    void testFindPendingNotificationsByRecipientId_ZeroId() {
+        // When & Then
+        assertDoesNotThrow(() -> {
+            List<NotificationEntity> result = repository.findPendingNotificationsByRecipientId(0L);
+            assertNotNull(result);
+        });
+    }
+
+    @Test
+    void testFindByRelatedTaskId_ZeroId() {
+        // When & Then
+        assertDoesNotThrow(() -> {
+            List<NotificationEntity> result = repository.findByRelatedTaskId(0L);
+            assertNotNull(result);
+        });
+    }
+
+    @Test
+    void testFindAllByRecipientId_LargeId() {
         // Given
-        MemoryNotificationRepository repository = new MemoryNotificationRepository();
         Long largeId = Long.MAX_VALUE;
 
         // When & Then
         assertDoesNotThrow(() -> {
-            List<NotificationEntity> result = repository.findAllByRecipientOrderByTimestampDesc(largeId);
-            assertTrue(result.isEmpty());
+            List<NotificationEntity> result = repository.findAllByRecipientId(largeId);
+            assertNotNull(result);
         });
+    }
 
+    @Test
+    void testFindPendingNotificationsByRecipientId_LargeId() {
+        // Given
+        Long largeId = Long.MAX_VALUE;
+
+        // When & Then
         assertDoesNotThrow(() -> {
-            List<NotificationEntity> result = repository.findUnviewedByRecipientOrderByTimestampDesc(largeId);
-            assertTrue(result.isEmpty());
+            List<NotificationEntity> result = repository.findPendingNotificationsByRecipientId(largeId);
+            assertNotNull(result);
         });
+    }
 
+    @Test
+    void testFindByRelatedTaskId_LargeId() {
+        // Given
+        Long largeId = Long.MAX_VALUE;
+
+        // When & Then
         assertDoesNotThrow(() -> {
-            Optional<NotificationEntity> result = repository.findById(largeId);
-            assertFalse(result.isPresent());
+            List<NotificationEntity> result = repository.findByRelatedTaskId(largeId);
+            assertNotNull(result);
         });
     }
 }

--- a/src/test/java/org/example/taskmanager/repository/memory/MemoryTaskRepositoryTest.java
+++ b/src/test/java/org/example/taskmanager/repository/memory/MemoryTaskRepositoryTest.java
@@ -68,16 +68,16 @@ class MemoryTaskRepositoryTest {
                 .build();
 
         // Store test data
-        repository.store(task1);
-        repository.store(task2);
-        repository.store(task3);
-        repository.store(removedTask);
+        repository.save(task1);
+        repository.save(task2);
+        repository.save(task3);
+        repository.save(removedTask);
     }
 
     @Test
     void testFindAllByOwnerAndNotRemoved_Success() {
         // When
-        List<TaskEntity> result = repository.findAllByOwnerAndNotRemoved(ownerId1);
+        List<TaskEntity> result = repository.findAllByOwnerId(ownerId1);
 
         // Then
         assertEquals(2, result.size());
@@ -92,7 +92,7 @@ class MemoryTaskRepositoryTest {
         Long nonExistentOwnerId = 999L;
 
         // When
-        List<TaskEntity> result = repository.findAllByOwnerAndNotRemoved(nonExistentOwnerId);
+        List<TaskEntity> result = repository.findAllByOwnerId(nonExistentOwnerId);
 
         // Then
         assertTrue(result.isEmpty());
@@ -101,7 +101,7 @@ class MemoryTaskRepositoryTest {
     @Test
     void testFindAllByOwnerAndNotRemoved_DifferentOwner() {
         // When
-        List<TaskEntity> result = repository.findAllByOwnerAndNotRemoved(ownerId2);
+        List<TaskEntity> result = repository.findAllByOwnerId(ownerId2);
 
         // Then
         assertEquals(1, result.size());
@@ -111,7 +111,7 @@ class MemoryTaskRepositoryTest {
     @Test
     void testFindPendingByOwnerAndNotRemoved_Success() {
         // When
-        List<TaskEntity> result = repository.findPendingByOwnerAndNotRemoved(ownerId1);
+        List<TaskEntity> result = repository.findPendingTasksByOwnerId(ownerId1);
 
         // Then
         assertEquals(1, result.size());
@@ -126,7 +126,7 @@ class MemoryTaskRepositoryTest {
         Long nonExistentOwnerId = 999L;
 
         // When
-        List<TaskEntity> result = repository.findPendingByOwnerAndNotRemoved(nonExistentOwnerId);
+        List<TaskEntity> result = repository.findPendingTasksByOwnerId(nonExistentOwnerId);
 
         // Then
         assertTrue(result.isEmpty());
@@ -143,10 +143,10 @@ class MemoryTaskRepositoryTest {
                 .finished(true)
                 .removed(false)
                 .build();
-        repository.store(finishedTask);
+        repository.save(finishedTask);
 
         // When
-        List<TaskEntity> result = repository.findPendingByOwnerAndNotRemoved(ownerId1);
+        List<TaskEntity> result = repository.findPendingTasksByOwnerId(ownerId1);
 
         // Then
         assertEquals(1, result.size()); // Only task1 is pending
@@ -159,7 +159,7 @@ class MemoryTaskRepositoryTest {
         Long taskId = task1.getId();
 
         // When
-        Optional<TaskEntity> result = repository.findByIdAndNotRemoved(taskId);
+        Optional<TaskEntity> result = repository.findByIdAndOwnerId(taskId, ownerId1);
 
         // Then
         assertTrue(result.isPresent());
@@ -172,7 +172,7 @@ class MemoryTaskRepositoryTest {
         Long nonExistentTaskId = 999L;
 
         // When
-        Optional<TaskEntity> result = repository.findByIdAndNotRemoved(nonExistentTaskId);
+        Optional<TaskEntity> result = repository.findByIdAndOwnerId(nonExistentTaskId, ownerId1);
 
         // Then
         assertFalse(result.isPresent());
@@ -184,7 +184,7 @@ class MemoryTaskRepositoryTest {
         Long removedTaskId = removedTask.getId();
 
         // When
-        Optional<TaskEntity> result = repository.findByIdAndNotRemoved(removedTaskId);
+        Optional<TaskEntity> result = repository.findByIdAndOwnerId(removedTaskId, ownerId1);
 
         // Then
         assertFalse(result.isPresent());
@@ -203,7 +203,7 @@ class MemoryTaskRepositoryTest {
                 .build();
 
         // When
-        TaskEntity result = repository.store(newTask);
+        TaskEntity result = repository.save(newTask);
 
         // Then
         assertNotNull(result.getId());
@@ -211,7 +211,7 @@ class MemoryTaskRepositoryTest {
         assertEquals(ownerId1, result.getOwnerId());
         
         // Verify it can be found
-        Optional<TaskEntity> foundTask = repository.findByIdAndNotRemoved(result.getId());
+        Optional<TaskEntity> foundTask = repository.findByIdAndOwnerId(result.getId(), ownerId1);
         assertTrue(foundTask.isPresent());
         assertEquals(result, foundTask.get());
     }
@@ -219,12 +219,12 @@ class MemoryTaskRepositoryTest {
     @Test
     void testStore_UpdateTask() {
         // Given
-        TaskEntity existingTask = repository.store(task1);
+        TaskEntity existingTask = repository.save(task1);
         existingTask.setName("Updated Task Name");
         existingTask.setFinished(true);
 
         // When
-        TaskEntity result = repository.store(existingTask);
+        TaskEntity result = repository.save(existingTask);
 
         // Then
         assertEquals(existingTask.getId(), result.getId());
@@ -232,7 +232,7 @@ class MemoryTaskRepositoryTest {
         assertTrue(result.getFinished());
         
         // Verify the update
-        Optional<TaskEntity> foundTask = repository.findByIdAndNotRemoved(result.getId());
+        Optional<TaskEntity> foundTask = repository.findByIdAndOwnerId(result.getId(), ownerId1);
         assertTrue(foundTask.isPresent());
         assertEquals("Updated Task Name", foundTask.get().getName());
         assertTrue(foundTask.get().getFinished());
@@ -256,8 +256,8 @@ class MemoryTaskRepositoryTest {
                 .build();
 
         // When
-        TaskEntity resultA = repository.store(taskA);
-        TaskEntity resultB = repository.store(taskB);
+        TaskEntity resultA = repository.save(taskA);
+        TaskEntity resultB = repository.save(taskB);
 
         // Then
         assertNotNull(resultA.getId());
@@ -265,7 +265,7 @@ class MemoryTaskRepositoryTest {
         assertNotEquals(resultA.getId(), resultB.getId());
         
         // Verify both can be found
-        List<TaskEntity> allTasks = repository.findAllByOwnerAndNotRemoved(ownerId1);
+        List<TaskEntity> allTasks = repository.findAllByOwnerId(ownerId1);
         assertTrue(allTasks.size() >= 4); // task1, task2, taskA, taskB
     }
 
@@ -287,8 +287,8 @@ class MemoryTaskRepositoryTest {
                 .build();
 
         // When
-        TaskEntity result1 = repository.store(task1);
-        TaskEntity result2 = repository.store(task2);
+        TaskEntity result1 = repository.save(task1);
+        TaskEntity result2 = repository.save(task2);
 
         // Then
         assertNotNull(result1.getId());

--- a/src/test/java/org/example/taskmanager/repository/memory/MemoryUserRepositoryTest.java
+++ b/src/test/java/org/example/taskmanager/repository/memory/MemoryUserRepositoryTest.java
@@ -35,8 +35,8 @@ class MemoryUserRepositoryTest {
                 .build();
 
         // Store test data
-        repository.store(user1);
-        repository.store(user2);
+        repository.save(user1);
+        repository.save(user2);
     }
 
     @Test
@@ -80,7 +80,7 @@ class MemoryUserRepositoryTest {
                 .build();
 
         // When
-        UserEntity result = repository.store(newUser);
+        UserEntity result = repository.save(newUser);
 
         // Then
         assertNotNull(result.getId());
@@ -97,12 +97,12 @@ class MemoryUserRepositoryTest {
     @Test
     void testStore_UpdateUser() {
         // Given
-        UserEntity existingUser = repository.store(user1);
+        UserEntity existingUser = repository.save(user1);
         existingUser.setPasswordHash("updatedpassword");
         existingUser.setEmailAddress("updated@example.com");
 
         // When
-        UserEntity result = repository.store(existingUser);
+        UserEntity result = repository.save(existingUser);
 
         // Then
         assertEquals(existingUser.getId(), result.getId());
@@ -119,7 +119,7 @@ class MemoryUserRepositoryTest {
     @Test
     void testCheckLoginExists_ExistingLogin() {
         // When
-        boolean exists = repository.checkLoginExists("user1");
+        boolean exists = repository.existsByLogin("user1");
 
         // Then
         assertTrue(exists);
@@ -128,7 +128,7 @@ class MemoryUserRepositoryTest {
     @Test
     void testCheckLoginExists_NonExistentLogin() {
         // When
-        boolean exists = repository.checkLoginExists("nonexistent");
+        boolean exists = repository.existsByLogin("nonexistent");
 
         // Then
         assertFalse(exists);
@@ -137,7 +137,7 @@ class MemoryUserRepositoryTest {
     @Test
     void testCheckLoginExists_CaseSensitive() {
         // When
-        boolean exists = repository.checkLoginExists("USER1");
+        boolean exists = repository.existsByLogin("USER1");
 
         // Then
         assertFalse(exists);
@@ -146,7 +146,7 @@ class MemoryUserRepositoryTest {
     @Test
     void testCheckEmailExists_ExistingEmail() {
         // When
-        boolean exists = repository.checkEmailExists("user1@example.com");
+        boolean exists = repository.existsByEmailAddress("user1@example.com");
 
         // Then
         assertTrue(exists);
@@ -155,7 +155,7 @@ class MemoryUserRepositoryTest {
     @Test
     void testCheckEmailExists_NonExistentEmail() {
         // When
-        boolean exists = repository.checkEmailExists("nonexistent@example.com");
+        boolean exists = repository.existsByEmailAddress("nonexistent@example.com");
 
         // Then
         assertFalse(exists);
@@ -164,7 +164,7 @@ class MemoryUserRepositoryTest {
     @Test
     void testCheckEmailExists_CaseSensitive() {
         // When
-        boolean exists = repository.checkEmailExists("USER1@EXAMPLE.COM");
+        boolean exists = repository.existsByEmailAddress("USER1@EXAMPLE.COM");
 
         // Then
         assertFalse(exists);
@@ -186,8 +186,8 @@ class MemoryUserRepositoryTest {
                 .build();
 
         // When
-        UserEntity resultA = repository.store(userA);
-        UserEntity resultB = repository.store(userB);
+        UserEntity resultA = repository.save(userA);
+        UserEntity resultB = repository.save(userB);
 
         // Then
         assertNotNull(resultA.getId());
@@ -205,16 +205,16 @@ class MemoryUserRepositoryTest {
                 .build();
 
         // When
-        repository.store(user3);
+        repository.save(user3);
 
         // Then
-        assertTrue(repository.checkLoginExists("user1"));
-        assertTrue(repository.checkLoginExists("user2"));
-        assertTrue(repository.checkLoginExists("user3"));
+        assertTrue(repository.existsByLogin("user1"));
+        assertTrue(repository.existsByLogin("user2"));
+        assertTrue(repository.existsByLogin("user3"));
 
-        assertTrue(repository.checkEmailExists("user1@example.com"));
-        assertTrue(repository.checkEmailExists("user2@example.com"));
-        assertTrue(repository.checkEmailExists("user3@example.com"));
+        assertTrue(repository.existsByEmailAddress("user1@example.com"));
+        assertTrue(repository.existsByEmailAddress("user2@example.com"));
+        assertTrue(repository.existsByEmailAddress("user3@example.com"));
     }
 
     @Test
@@ -227,7 +227,7 @@ class MemoryUserRepositoryTest {
                 .build();
 
         // When
-        UserEntity result = repository.store(specialUser);
+        UserEntity result = repository.save(specialUser);
 
         // Then
         assertEquals("user.name+tag", result.getLogin());
@@ -235,7 +235,7 @@ class MemoryUserRepositoryTest {
         assertEquals("user.name+tag@example-domain.co.uk", result.getEmailAddress());
 
         // Verify it can be found
-        assertTrue(repository.checkLoginExists("user.name+tag"));
-        assertTrue(repository.checkEmailExists("user.name+tag@example-domain.co.uk"));
+        assertTrue(repository.existsByLogin("user.name+tag"));
+        assertTrue(repository.existsByEmailAddress("user.name+tag@example-domain.co.uk"));
     }
 }

--- a/src/test/java/org/example/taskmanager/service/NotificationManagementServiceTest.java
+++ b/src/test/java/org/example/taskmanager/service/NotificationManagementServiceTest.java
@@ -4,14 +4,11 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import org.example.taskmanager.domain.NotificationEntity;
-import org.example.taskmanager.exception.EntityNotFoundException;
 import org.example.taskmanager.repository.NotificationDataRepository;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -74,7 +71,7 @@ class NotificationManagementServiceTest {
     void testGetAllUserNotifications_Success() {
         // Given
         List<NotificationEntity> expectedNotifications = Arrays.asList(notification1, notification2, unreadNotification);
-        when(notificationRepository.findAllByRecipientOrderByTimestampDesc(testRecipientId))
+        when(notificationRepository.findAllByRecipientId(testRecipientId))
                 .thenReturn(expectedNotifications);
 
         // When
@@ -82,13 +79,13 @@ class NotificationManagementServiceTest {
 
         // Then
         assertEquals(expectedNotifications, actualNotifications);
-        verify(notificationRepository).findAllByRecipientOrderByTimestampDesc(testRecipientId);
+        verify(notificationRepository).findAllByRecipientId(testRecipientId);
     }
 
     @Test
     void testGetAllUserNotifications_EmptyResult() {
         // Given
-        when(notificationRepository.findAllByRecipientOrderByTimestampDesc(testRecipientId))
+        when(notificationRepository.findAllByRecipientId(testRecipientId))
                 .thenReturn(Collections.emptyList());
 
         // When
@@ -96,14 +93,14 @@ class NotificationManagementServiceTest {
 
         // Then
         assertTrue(actualNotifications.isEmpty());
-        verify(notificationRepository).findAllByRecipientOrderByTimestampDesc(testRecipientId);
+        verify(notificationRepository).findAllByRecipientId(testRecipientId);
     }
 
     @Test
     void testGetUnreadNotifications_Success() {
         // Given
         List<NotificationEntity> expectedNotifications = Collections.singletonList(unreadNotification);
-        when(notificationRepository.findUnviewedByRecipientOrderByTimestampDesc(testRecipientId))
+        when(notificationRepository.findPendingNotificationsByRecipientId(testRecipientId))
                 .thenReturn(expectedNotifications);
 
         // When
@@ -111,13 +108,13 @@ class NotificationManagementServiceTest {
 
         // Then
         assertEquals(expectedNotifications, actualNotifications);
-        verify(notificationRepository).findUnviewedByRecipientOrderByTimestampDesc(testRecipientId);
+        verify(notificationRepository).findPendingNotificationsByRecipientId(testRecipientId);
     }
 
     @Test
     void testGetUnreadNotifications_EmptyResult() {
         // Given
-        when(notificationRepository.findUnviewedByRecipientOrderByTimestampDesc(testRecipientId))
+        when(notificationRepository.findPendingNotificationsByRecipientId(testRecipientId))
                 .thenReturn(Collections.emptyList());
 
         // When
@@ -125,34 +122,9 @@ class NotificationManagementServiceTest {
 
         // Then
         assertTrue(actualNotifications.isEmpty());
-        verify(notificationRepository).findUnviewedByRecipientOrderByTimestampDesc(testRecipientId);
+        verify(notificationRepository).findPendingNotificationsByRecipientId(testRecipientId);
     }
 
-    @Test
-    void testGetNotificationDetails_Success() {
-        // Given
-        when(notificationRepository.findById(testNotificationId)).thenReturn(Optional.of(notification1));
-
-        // When
-        NotificationEntity actualNotification = notificationService.getNotificationDetails(testNotificationId);
-
-        // Then
-        assertEquals(notification1, actualNotification);
-        verify(notificationRepository).findById(testNotificationId);
-    }
-
-    @Test
-    void testGetNotificationDetails_NotificationNotFound() {
-        // Given
-        when(notificationRepository.findById(testNotificationId)).thenReturn(Optional.empty());
-
-        // When & Then
-        EntityNotFoundException exception = assertThrows(EntityNotFoundException.class,
-            () -> notificationService.getNotificationDetails(testNotificationId));
-        
-        assertEquals("Notification with id " + testNotificationId + " not found", exception.getMessage());
-        verify(notificationRepository).findById(testNotificationId);
-    }
 
     @Test
     void testGetAllUserNotifications_DifferentRecipients() {
@@ -167,9 +139,9 @@ class NotificationManagementServiceTest {
                 .viewed(false)
                 .build();
 
-        when(notificationRepository.findAllByRecipientOrderByTimestampDesc(testRecipientId))
+        when(notificationRepository.findAllByRecipientId(testRecipientId))
                 .thenReturn(Arrays.asList(notification1, notification2, unreadNotification));
-        when(notificationRepository.findAllByRecipientOrderByTimestampDesc(recipientId2))
+        when(notificationRepository.findAllByRecipientId(recipientId2))
                 .thenReturn(Collections.singletonList(notificationForUser2));
 
         // When
@@ -191,9 +163,9 @@ class NotificationManagementServiceTest {
         List<NotificationEntity> allNotifications = Arrays.asList(notification1, notification2, unreadNotification);
         List<NotificationEntity> unreadNotifications = Collections.singletonList(unreadNotification);
 
-        when(notificationRepository.findAllByRecipientOrderByTimestampDesc(testRecipientId))
+        when(notificationRepository.findAllByRecipientId(testRecipientId))
                 .thenReturn(allNotifications);
-        when(notificationRepository.findUnviewedByRecipientOrderByTimestampDesc(testRecipientId))
+        when(notificationRepository.findPendingNotificationsByRecipientId(testRecipientId))
                 .thenReturn(unreadNotifications);
 
         // When
@@ -230,7 +202,7 @@ class NotificationManagementServiceTest {
                 .build();
 
         List<NotificationEntity> orderedNotifications = Arrays.asList(newerNotification, unreadNotification, olderNotification);
-        when(notificationRepository.findAllByRecipientOrderByTimestampDesc(testRecipientId))
+        when(notificationRepository.findAllByRecipientId(testRecipientId))
                 .thenReturn(orderedNotifications);
 
         // When
@@ -243,26 +215,4 @@ class NotificationManagementServiceTest {
         assertEquals(olderNotification, result.get(2));
     }
 
-    @Test
-    void testNotificationWithNullValues() {
-        // Given
-        NotificationEntity notificationWithNulls = NotificationEntity.builder()
-                .id(7L)
-                .message("Test notification")
-                .timestamp(LocalDateTime.now())
-                .relatedTaskId(1L) // Use valid ID to avoid NPE
-                .recipientId(1L)   // Use valid ID to avoid NPE
-                .viewed(false)
-                .build();
-
-        when(notificationRepository.findById(7L)).thenReturn(Optional.of(notificationWithNulls));
-
-        // When
-        NotificationEntity result = notificationService.getNotificationDetails(7L);
-
-        // Then
-        assertEquals(notificationWithNulls, result);
-        assertEquals(1L, result.getRelatedTaskId());
-        assertEquals(1L, result.getRecipientId());
-    }
 }

--- a/src/test/java/org/example/taskmanager/service/TaskManagementServiceTest.java
+++ b/src/test/java/org/example/taskmanager/service/TaskManagementServiceTest.java
@@ -79,80 +79,80 @@ class TaskManagementServiceTest {
     void testGetAllUserTasks_Success() {
         // Given
         List<TaskEntity> expectedTasks = Arrays.asList(validTask, completedTask);
-        when(taskRepository.findAllByOwnerAndNotRemoved(testOwnerId)).thenReturn(expectedTasks);
+        when(taskRepository.findAllByOwnerId(testOwnerId)).thenReturn(expectedTasks);
 
         // When
         List<TaskEntity> actualTasks = taskService.getAllUserTasks(testOwnerId);
 
         // Then
         assertEquals(expectedTasks, actualTasks);
-        verify(taskRepository).findAllByOwnerAndNotRemoved(testOwnerId);
+        verify(taskRepository).findAllByOwnerId(testOwnerId);
     }
 
     @Test
     void testGetAllUserTasks_EmptyResult() {
         // Given
-        when(taskRepository.findAllByOwnerAndNotRemoved(testOwnerId)).thenReturn(Collections.emptyList());
+        when(taskRepository.findAllByOwnerId(testOwnerId)).thenReturn(Collections.emptyList());
 
         // When
         List<TaskEntity> actualTasks = taskService.getAllUserTasks(testOwnerId);
 
         // Then
         assertTrue(actualTasks.isEmpty());
-        verify(taskRepository).findAllByOwnerAndNotRemoved(testOwnerId);
+        verify(taskRepository).findAllByOwnerId(testOwnerId);
     }
 
     @Test
     void testGetActiveTasks_Success() {
         // Given
         List<TaskEntity> expectedTasks = Collections.singletonList(validTask);
-        when(taskRepository.findPendingByOwnerAndNotRemoved(testOwnerId)).thenReturn(expectedTasks);
+        when(taskRepository.findPendingTasksByOwnerId(testOwnerId)).thenReturn(expectedTasks);
 
         // When
         List<TaskEntity> actualTasks = taskService.getActiveTasks(testOwnerId);
 
         // Then
         assertEquals(expectedTasks, actualTasks);
-        verify(taskRepository).findPendingByOwnerAndNotRemoved(testOwnerId);
+        verify(taskRepository).findPendingTasksByOwnerId(testOwnerId);
     }
 
     @Test
     void testGetActiveTasks_EmptyResult() {
         // Given
-        when(taskRepository.findPendingByOwnerAndNotRemoved(testOwnerId)).thenReturn(Collections.emptyList());
+        when(taskRepository.findPendingTasksByOwnerId(testOwnerId)).thenReturn(Collections.emptyList());
 
         // When
         List<TaskEntity> actualTasks = taskService.getActiveTasks(testOwnerId);
 
         // Then
         assertTrue(actualTasks.isEmpty());
-        verify(taskRepository).findPendingByOwnerAndNotRemoved(testOwnerId);
+        verify(taskRepository).findPendingTasksByOwnerId(testOwnerId);
     }
 
     @Test
     void testGetTaskDetails_Success() {
         // Given
-        when(taskRepository.findByIdAndNotRemoved(testTaskId)).thenReturn(Optional.of(validTask));
+        when(taskRepository.findByIdAndOwnerId(testTaskId, testOwnerId)).thenReturn(Optional.of(validTask));
 
         // When
-        TaskEntity actualTask = taskService.getTaskDetails(testTaskId);
+        TaskEntity actualTask = taskService.getTaskDetails(testTaskId, testOwnerId);
 
         // Then
         assertEquals(validTask, actualTask);
-        verify(taskRepository).findByIdAndNotRemoved(testTaskId);
+        verify(taskRepository).findByIdAndOwnerId(testTaskId, testOwnerId);
     }
 
     @Test
     void testGetTaskDetails_TaskNotFound() {
         // Given
-        when(taskRepository.findByIdAndNotRemoved(testTaskId)).thenReturn(Optional.empty());
+        when(taskRepository.findByIdAndOwnerId(testTaskId, testOwnerId)).thenReturn(Optional.empty());
 
         // When & Then
         EntityNotFoundException exception = assertThrows(EntityNotFoundException.class, 
-            () -> taskService.getTaskDetails(testTaskId));
+            () -> taskService.getTaskDetails(testTaskId, testOwnerId));
         
         assertEquals("Task with id " + testTaskId + " not found", exception.getMessage());
-        verify(taskRepository).findByIdAndNotRemoved(testTaskId);
+        verify(taskRepository).findByIdAndOwnerId(testTaskId, testOwnerId);
     }
 
     @Test
@@ -175,7 +175,7 @@ class TaskManagementServiceTest {
                 .removed(false)
                 .build();
 
-        when(taskRepository.store(any(TaskEntity.class))).thenReturn(savedTask);
+        when(taskRepository.save(any(TaskEntity.class))).thenReturn(savedTask);
 
         // When
         TaskEntity result = taskService.addNewTask(newTask);
@@ -185,7 +185,7 @@ class TaskManagementServiceTest {
         assertEquals(testTaskId, result.getId());
         assertEquals("New Task", result.getName());
         assertNotNull(result.getCreateTime());
-        verify(taskRepository).store(any(TaskEntity.class));
+        verify(taskRepository).save(any(TaskEntity.class));
     }
 
     @Test
@@ -203,7 +203,7 @@ class TaskManagementServiceTest {
             () -> taskService.addNewTask(invalidTask));
         
         assertEquals("Task name must not be empty", exception.getMessage());
-        verify(taskRepository, never()).store(any(TaskEntity.class));
+        verify(taskRepository, never()).save(any(TaskEntity.class));
     }
 
     @Test
@@ -221,7 +221,7 @@ class TaskManagementServiceTest {
             () -> taskService.addNewTask(invalidTask));
         
         assertEquals("Task details must not be empty", exception.getMessage());
-        verify(taskRepository, never()).store(any(TaskEntity.class));
+        verify(taskRepository, never()).save(any(TaskEntity.class));
     }
 
     @Test
@@ -239,34 +239,34 @@ class TaskManagementServiceTest {
             () -> taskService.addNewTask(invalidTask));
         
         assertEquals("Task due date cannot be in the past", exception.getMessage());
-        verify(taskRepository, never()).store(any(TaskEntity.class));
+        verify(taskRepository, never()).save(any(TaskEntity.class));
     }
 
     @Test
     void testRemoveTask_Success() {
         // Given
-        when(taskRepository.findByIdAndNotRemoved(testTaskId)).thenReturn(Optional.of(validTask));
-        when(taskRepository.store(any(TaskEntity.class))).thenReturn(validTask);
+        when(taskRepository.findByIdAndOwnerId(testTaskId, testOwnerId)).thenReturn(Optional.of(validTask));
+        when(taskRepository.save(any(TaskEntity.class))).thenReturn(validTask);
 
         // When
-        taskService.removeTask(testTaskId);
+        taskService.removeTask(testTaskId, testOwnerId);
 
         // Then
-        verify(taskRepository).findByIdAndNotRemoved(testTaskId);
-        verify(taskRepository).store(any(TaskEntity.class));
+        verify(taskRepository).findByIdAndOwnerId(testTaskId, testOwnerId);
+        verify(taskRepository).save(any(TaskEntity.class));
     }
 
     @Test
     void testRemoveTask_TaskNotFound() {
         // Given
-        when(taskRepository.findByIdAndNotRemoved(testTaskId)).thenReturn(Optional.empty());
+        when(taskRepository.findByIdAndOwnerId(testTaskId, testOwnerId)).thenReturn(Optional.empty());
 
         // When & Then
         EntityNotFoundException exception = assertThrows(EntityNotFoundException.class,
-            () -> taskService.removeTask(testTaskId));
+            () -> taskService.removeTask(testTaskId, testOwnerId));
         
         assertEquals("Task with id " + testTaskId + " not found", exception.getMessage());
-        verify(taskRepository).findByIdAndNotRemoved(testTaskId);
-        verify(taskRepository, never()).store(any(TaskEntity.class));
+        verify(taskRepository).findByIdAndOwnerId(testTaskId, testOwnerId);
+        verify(taskRepository, never()).save(any(TaskEntity.class));
     }
 }

--- a/src/test/java/org/example/taskmanager/service/UserManagementServiceTest.java
+++ b/src/test/java/org/example/taskmanager/service/UserManagementServiceTest.java
@@ -52,18 +52,18 @@ class UserManagementServiceTest {
     @Test
     void testCreateUserAccount_Success() {
         // Given
-        when(userRepository.checkLoginExists("testuser")).thenReturn(false);
-        when(userRepository.checkEmailExists("test@example.com")).thenReturn(false);
-        when(userRepository.store(any(UserEntity.class))).thenReturn(validUser);
+        when(userRepository.existsByLogin("testuser")).thenReturn(false);
+        when(userRepository.existsByEmailAddress("test@example.com")).thenReturn(false);
+        when(userRepository.save(any(UserEntity.class))).thenReturn(validUser);
 
         // When
         UserEntity result = userService.createUserAccount(validUser);
 
         // Then
         assertEquals(validUser, result);
-        verify(userRepository).checkLoginExists("testuser");
-        verify(userRepository).checkEmailExists("test@example.com");
-        verify(userRepository).store(any(UserEntity.class));
+        verify(userRepository).existsByLogin("testuser");
+        verify(userRepository).existsByEmailAddress("test@example.com");
+        verify(userRepository).save(any(UserEntity.class));
     }
 
     @Test
@@ -80,7 +80,7 @@ class UserManagementServiceTest {
             () -> userService.createUserAccount(invalidUser));
         
         assertEquals("Login must not be empty", exception.getMessage());
-        verify(userRepository, never()).store(any(UserEntity.class));
+        verify(userRepository, never()).save(any(UserEntity.class));
     }
 
     @Test
@@ -97,7 +97,7 @@ class UserManagementServiceTest {
             () -> userService.createUserAccount(invalidUser));
         
         assertEquals("Login must be at least 3 characters long", exception.getMessage());
-        verify(userRepository, never()).store(any(UserEntity.class));
+        verify(userRepository, never()).save(any(UserEntity.class));
     }
 
     @Test
@@ -114,7 +114,7 @@ class UserManagementServiceTest {
             () -> userService.createUserAccount(invalidUser));
         
         assertEquals("Password must not be empty", exception.getMessage());
-        verify(userRepository, never()).store(any(UserEntity.class));
+        verify(userRepository, never()).save(any(UserEntity.class));
     }
 
     @Test
@@ -131,7 +131,7 @@ class UserManagementServiceTest {
             () -> userService.createUserAccount(invalidUser));
         
         assertEquals("Password must be at least 6 characters long", exception.getMessage());
-        verify(userRepository, never()).store(any(UserEntity.class));
+        verify(userRepository, never()).save(any(UserEntity.class));
     }
 
     @Test
@@ -148,7 +148,7 @@ class UserManagementServiceTest {
             () -> userService.createUserAccount(invalidUser));
         
         assertEquals("Email must not be empty", exception.getMessage());
-        verify(userRepository, never()).store(any(UserEntity.class));
+        verify(userRepository, never()).save(any(UserEntity.class));
     }
 
     @Test
@@ -165,38 +165,38 @@ class UserManagementServiceTest {
             () -> userService.createUserAccount(invalidUser));
         
         assertEquals("Invalid email format", exception.getMessage());
-        verify(userRepository, never()).store(any(UserEntity.class));
+        verify(userRepository, never()).save(any(UserEntity.class));
     }
 
     @Test
     void testCreateUserAccount_DuplicateLogin() {
         // Given
-        when(userRepository.checkLoginExists("testuser")).thenReturn(true);
+        when(userRepository.existsByLogin("testuser")).thenReturn(true);
 
         // When & Then
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
             () -> userService.createUserAccount(validUser));
         
         assertEquals("Login already exists", exception.getMessage());
-        verify(userRepository).checkLoginExists("testuser");
-        verify(userRepository, never()).checkEmailExists(anyString());
-        verify(userRepository, never()).store(any(UserEntity.class));
+        verify(userRepository).existsByLogin("testuser");
+        verify(userRepository, never()).existsByEmailAddress(anyString());
+        verify(userRepository, never()).save(any(UserEntity.class));
     }
 
     @Test
     void testCreateUserAccount_DuplicateEmail() {
         // Given
-        when(userRepository.checkLoginExists("testuser")).thenReturn(false);
-        when(userRepository.checkEmailExists("test@example.com")).thenReturn(true);
+        when(userRepository.existsByLogin("testuser")).thenReturn(false);
+        when(userRepository.existsByEmailAddress("test@example.com")).thenReturn(true);
 
         // When & Then
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
             () -> userService.createUserAccount(validUser));
         
         assertEquals("Email already exists", exception.getMessage());
-        verify(userRepository).checkLoginExists("testuser");
-        verify(userRepository).checkEmailExists("test@example.com");
-        verify(userRepository, never()).store(any(UserEntity.class));
+        verify(userRepository).existsByLogin("testuser");
+        verify(userRepository).existsByEmailAddress("test@example.com");
+        verify(userRepository, never()).save(any(UserEntity.class));
     }
 
     @Test
@@ -247,16 +247,16 @@ class UserManagementServiceTest {
                 .emailAddress("valid@example.com")
                 .build();
 
-        when(userRepository.checkLoginExists("validuser")).thenReturn(false);
-        when(userRepository.checkEmailExists("valid@example.com")).thenReturn(false);
-        when(userRepository.store(any(UserEntity.class))).thenReturn(validUser);
+        when(userRepository.existsByLogin("validuser")).thenReturn(false);
+        when(userRepository.existsByEmailAddress("valid@example.com")).thenReturn(false);
+        when(userRepository.save(any(UserEntity.class))).thenReturn(validUser);
 
         // When
         UserEntity result = userService.createUserAccount(validUser);
 
         // Then
         assertNotNull(result);
-        verify(userRepository).store(any(UserEntity.class));
+        verify(userRepository).save(any(UserEntity.class));
     }
 
     @Test
@@ -276,9 +276,9 @@ class UserManagementServiceTest {
                     .emailAddress(email)
                     .build();
 
-            when(userRepository.checkLoginExists("testuser")).thenReturn(false);
-            when(userRepository.checkEmailExists(email)).thenReturn(false);
-            when(userRepository.store(any(UserEntity.class))).thenReturn(user);
+            when(userRepository.existsByLogin("testuser")).thenReturn(false);
+            when(userRepository.existsByEmailAddress(email)).thenReturn(false);
+            when(userRepository.save(any(UserEntity.class))).thenReturn(user);
 
             // When & Then
             assertDoesNotThrow(() -> userService.createUserAccount(user));


### PR DESCRIPTION


- Add H2 in-memory database with console support
- Implement Spring Data JPA integration with Hibernate
- Add JPA Entity annotations (@Entity, @Id, @GeneratedValue, @Table)
- Create JPA Repository interfaces and implementations
- Implement profile-based architecture:
  * inmemory profile - HashMap storage (Step 1-2)
  * h2 profile - JPA + H2 database (Step 3)
- Maintain backward compatibility with existing functionality
- Update all unit tests for new architecture
- Add application-h2.properties configuration

Completes Step 3: In-Memory Database (H2)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds H2 + Spring Data JPA with profile-based repos, JPA-annotated entities, refactors repo/service APIs, adjusts task delete endpoint, and updates tests/docs.
> 
> - **Persistence & Profiles**
>   - Add H2 and Spring Data JPA (`build.gradle`).
>   - Introduce `h2` profile with JPA repositories (`TaskJpaRepository`, `UserJpaRepository`, `NotificationJpaRepository`) and adapters under `repository/jpa/impl/*`.
>   - Keep `inmemory` profile; align memory repos to new method names/signatures.
> - **Domain Models**
>   - Annotate `TaskEntity`, `UserEntity`, `NotificationEntity` with JPA (`@Entity`, `@Table`, `@Id`, `@GeneratedValue`).
> - **Repository API Refactor**
>   - Rename methods: `store` -> `save`, `findAllByOwnerAndNotRemoved` -> `findAllByOwnerId`, etc.
>   - Add deletes and new queries (e.g., `deleteById`, `findByRelatedTaskId`).
> - **Services**
>   - Update to new repo API; `TaskManagementService.getTaskDetails`/`removeTask` now require `ownerId`.
>   - `NotificationManagementService` drops `getNotificationDetails`; uses new query methods.
> - **Web API**
>   - Change delete endpoint to `DELETE /api/tasks/{taskId}/user/{ownerId}`.
> - **Tests & Docs**
>   - Update unit tests to new method names/behaviors and add coverage for new queries.
>   - Expand README with Steps 1–3 and H2/JPA setup details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b4a6340b684cd7299f4ec0f932d39fd9f55b629. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->