### PR TITLE
feat: implement RabbitMQ messaging for async task notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,3 +236,54 @@
 - **Стабильные интеграционные тесты** 
 
 </details>
+
+<details>
+<summary><b>Step 7: Implement Messaging (RabbitMQ)</b></summary>
+
+### Цель
+Реализовать асинхронную обработку сообщений с использованием RabbitMQ для разделения создания задач и уведомлений
+
+### Реализованные функции
+- **RabbitMQ интеграция**: полная настройка RabbitMQ как message broker
+- **Message Publisher**: публикация событий создания/удаления задач
+- **Message Listener**: асинхронная обработка сообщений и создание уведомлений
+- **Topic Exchange**: гибкая маршрутизация сообщений по типам событий
+- **Профиль messaging**: отдельная конфигурация для работы с RabbitMQ
+- **Docker Compose**: обновленная оркестрация с RabbitMQ контейнером
+
+### Архитектура
+- **application-messaging.properties**: конфигурация RabbitMQ подключения и обработки
+- **RabbitMQConfig**: настройка exchanges, queues, bindings и Jackson сериализации
+- **TaskEventPublisher**: публикация событий задач в RabbitMQ
+- **TaskEventListener**: обработка сообщений и создание уведомлений
+- **TaskEventMessage**: DTO для передачи данных о событиях задач
+- **Условная конфигурация**: RabbitMQ компоненты активируются только при наличии настроек
+- **Docker Compose**: PostgreSQL + Redis + RabbitMQ + Spring Boot приложение
+
+### Технологии
+- RabbitMQ 3 Management Alpine
+- Spring AMQP
+- Spring Boot Starter AMQP
+- Jackson2JsonMessageConverter для сериализации
+- Topic Exchange с routing keys
+- Docker Compose с health checks
+- Условные Spring бины (@ConditionalOnProperty)
+
+### Тестирование
+- **TaskEventPublisherTest**: unit тесты публикации сообщений
+- **TaskEventListenerTest**: unit тесты обработки сообщений
+- **MessagingProfileIntegrationTest**: интеграционные тесты с RabbitMQ
+- **Автоматическое управление контейнерами**: Docker Compose плагин для Gradle
+- **Основные тесты проходят** успешно
+
+### Результат
+- **RabbitMQ messaging** 
+- **Асинхронная обработка событий** 
+- **Разделение ответственности** между созданием задач и уведомлений
+- **Topic Exchange с гибкой маршрутизацией** 
+- **Условная активация** RabbitMQ компонентов
+- **Все профили работают** (inmemory, h2, docker, postgresql, cache, messaging) 
+- **Docker Compose с PostgreSQL + Redis + RabbitMQ** 
+- **Стабильная сборка проекта** 
+
+</details>

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-amqp' // Added for RabbitMQ messaging
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-database-postgresql'
 	implementation 'com.h2database:h2'
@@ -30,6 +31,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.amqp:spring-rabbit-test' // Added for RabbitMQ testing
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
@@ -41,8 +43,8 @@ tasks.named('test') {
 dockerCompose {
 	useComposeFiles = ['docker-compose.yml']
 	
-	// Start PostgreSQL and Redis services for tests
-	startedServices = ['postgres', 'redis']
+	// Start PostgreSQL, Redis and RabbitMQ services for tests
+	startedServices = ['postgres', 'redis', 'rabbitmq']
 	
 	// Wait for services to be ready
 	waitForTcpPorts = true
@@ -55,12 +57,16 @@ dockerCompose {
 	removeOrphans = true
 	
 	// Environment variables for tests
-	environment.put 'SPRING_PROFILES_ACTIVE', 'docker'
+	environment.put 'SPRING_PROFILES_ACTIVE', 'messaging'
 	environment.put 'SPRING_DATASOURCE_URL', 'jdbc:postgresql://localhost:5433/taskmanager'
 	environment.put 'SPRING_DATASOURCE_USERNAME', 'taskmanager'
 	environment.put 'SPRING_DATASOURCE_PASSWORD', 'taskmanager123'
 	environment.put 'SPRING_REDIS_HOST', 'localhost'
 	environment.put 'SPRING_REDIS_PORT', '6379'
+	environment.put 'SPRING_RABBITMQ_HOST', 'localhost'
+	environment.put 'SPRING_RABBITMQ_PORT', '5672'
+	environment.put 'SPRING_RABBITMQ_USERNAME', 'taskmanager'
+	environment.put 'SPRING_RABBITMQ_PASSWORD', 'taskmanager123'
 }
 
 // Make test task depend on composeUp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,17 +34,41 @@ services:
       retries: 5
     command: redis-server --appendonly yes
 
+  # RabbitMQ Message Broker
+  rabbitmq:
+    image: rabbitmq:3-management-alpine
+    container_name: taskmanager-rabbitmq
+    environment:
+      RABBITMQ_DEFAULT_USER: taskmanager
+      RABBITMQ_DEFAULT_PASS: taskmanager123
+      RABBITMQ_DEFAULT_VHOST: /
+    ports:
+      - "5672:5672"   # AMQP port
+      - "15672:15672" # Management UI port
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   # Spring Boot Application
   app:
     build: .
     container_name: taskmanager-app
     environment:
-      SPRING_PROFILES_ACTIVE: docker
+      SPRING_PROFILES_ACTIVE: messaging
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/taskmanager
       SPRING_DATASOURCE_USERNAME: taskmanager
       SPRING_DATASOURCE_PASSWORD: taskmanager123
       SPRING_REDIS_HOST: redis
       SPRING_REDIS_PORT: 6379
+      SPRING_RABBITMQ_HOST: rabbitmq
+      SPRING_RABBITMQ_PORT: 5672
+      SPRING_RABBITMQ_USERNAME: taskmanager
+      SPRING_RABBITMQ_PASSWORD: taskmanager123
     ports:
       - "8080:8080"
     depends_on:
@@ -52,8 +76,11 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
     restart: unless-stopped
 
 volumes:
   postgres_data:
   redis_data:
+  rabbitmq_data:

--- a/src/main/java/org/example/taskmanager/config/RabbitMQConfig.java
+++ b/src/main/java/org/example/taskmanager/config/RabbitMQConfig.java
@@ -1,0 +1,100 @@
+package org.example.taskmanager.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(name = "spring.rabbitmq.host")
+public class RabbitMQConfig {
+
+    // Queue names
+    public static final String TASK_CREATED_QUEUE = "task.created.queue";
+    public static final String TASK_UPDATED_QUEUE = "task.updated.queue";
+    public static final String TASK_DELETED_QUEUE = "task.deleted.queue";
+    
+    // Exchange names
+    public static final String TASK_EXCHANGE = "task.exchange";
+    
+    // Routing keys
+    public static final String TASK_CREATED_ROUTING_KEY = "task.created";
+    public static final String TASK_UPDATED_ROUTING_KEY = "task.updated";
+    public static final String TASK_DELETED_ROUTING_KEY = "task.deleted";
+
+    @Bean
+    public MessageConverter messageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+        RabbitTemplate template = new RabbitTemplate(connectionFactory);
+        template.setMessageConverter(messageConverter());
+        return template;
+    }
+
+    @Bean
+    public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory(ConnectionFactory connectionFactory) {
+        SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+        factory.setConnectionFactory(connectionFactory);
+        factory.setMessageConverter(messageConverter());
+        return factory;
+    }
+
+    // Exchange
+    @Bean
+    public TopicExchange taskExchange() {
+        return new TopicExchange(TASK_EXCHANGE);
+    }
+
+    // Queues
+    @Bean
+    public Queue taskCreatedQueue() {
+        return QueueBuilder.durable(TASK_CREATED_QUEUE).build();
+    }
+
+    @Bean
+    public Queue taskUpdatedQueue() {
+        return QueueBuilder.durable(TASK_UPDATED_QUEUE).build();
+    }
+
+    @Bean
+    public Queue taskDeletedQueue() {
+        return QueueBuilder.durable(TASK_DELETED_QUEUE).build();
+    }
+
+    // Bindings
+    @Bean
+    public Binding taskCreatedBinding() {
+        return BindingBuilder
+                .bind(taskCreatedQueue())
+                .to(taskExchange())
+                .with(TASK_CREATED_ROUTING_KEY);
+    }
+
+    @Bean
+    public Binding taskUpdatedBinding() {
+        return BindingBuilder
+                .bind(taskUpdatedQueue())
+                .to(taskExchange())
+                .with(TASK_UPDATED_ROUTING_KEY);
+    }
+
+    @Bean
+    public Binding taskDeletedBinding() {
+        return BindingBuilder
+                .bind(taskDeletedQueue())
+                .to(taskExchange())
+                .with(TASK_DELETED_ROUTING_KEY);
+    }
+}

--- a/src/main/java/org/example/taskmanager/messaging/TaskEventListener.java
+++ b/src/main/java/org/example/taskmanager/messaging/TaskEventListener.java
@@ -1,0 +1,104 @@
+package org.example.taskmanager.messaging;
+
+import java.time.LocalDateTime;
+
+import org.example.taskmanager.config.RabbitMQConfig;
+import org.example.taskmanager.domain.NotificationEntity;
+import org.example.taskmanager.repository.NotificationDataRepository;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@ConditionalOnProperty(name = "spring.rabbitmq.host")
+@RequiredArgsConstructor
+@Slf4j
+public class TaskEventListener {
+
+    private final NotificationDataRepository notificationRepository;
+
+    @RabbitListener(queues = RabbitMQConfig.TASK_CREATED_QUEUE)
+    @CacheEvict(value = "notifications", allEntries = true)
+    public void handleTaskCreated(TaskEventMessage message) {
+        try {
+            log.info("Received task created event for task ID: {}, owner: {}", 
+                    message.getTaskId(), message.getOwnerLogin());
+
+            // Create notification for task creation
+            NotificationEntity notification = NotificationEntity.builder()
+                    .message("New task created: " + message.getTaskName())
+                    .relatedTaskId(message.getTaskId())
+                    .recipientId(message.getOwnerId())
+                    .viewed(false)
+                    .timestamp(LocalDateTime.now())
+                    .build();
+
+            notificationRepository.save(notification);
+            
+            log.info("Created notification for task creation: task ID {}, recipient ID {}", 
+                    message.getTaskId(), message.getOwnerId());
+        } catch (Exception e) {
+            log.error("Failed to process task created event for task ID: {}", message.getTaskId(), e);
+            // Re-throw to trigger retry mechanism
+            throw e;
+        }
+    }
+
+    @RabbitListener(queues = RabbitMQConfig.TASK_UPDATED_QUEUE)
+    @CacheEvict(value = "notifications", allEntries = true)
+    public void handleTaskUpdated(TaskEventMessage message) {
+        try {
+            log.info("Received task updated event for task ID: {}, owner: {}", 
+                    message.getTaskId(), message.getOwnerLogin());
+
+            // Create notification for task update
+            NotificationEntity notification = NotificationEntity.builder()
+                    .message("Task updated: " + message.getTaskName())
+                    .relatedTaskId(message.getTaskId())
+                    .recipientId(message.getOwnerId())
+                    .viewed(false)
+                    .timestamp(LocalDateTime.now())
+                    .build();
+
+            notificationRepository.save(notification);
+            
+            log.info("Created notification for task update: task ID {}, recipient ID {}", 
+                    message.getTaskId(), message.getOwnerId());
+        } catch (Exception e) {
+            log.error("Failed to process task updated event for task ID: {}", message.getTaskId(), e);
+            // Re-throw to trigger retry mechanism
+            throw e;
+        }
+    }
+
+    @RabbitListener(queues = RabbitMQConfig.TASK_DELETED_QUEUE)
+    @CacheEvict(value = "notifications", allEntries = true)
+    public void handleTaskDeleted(TaskEventMessage message) {
+        try {
+            log.info("Received task deleted event for task ID: {}, owner: {}", 
+                    message.getTaskId(), message.getOwnerLogin());
+
+            // Create notification for task deletion
+            NotificationEntity notification = NotificationEntity.builder()
+                    .message("Task deleted: " + message.getTaskName())
+                    .relatedTaskId(message.getTaskId())
+                    .recipientId(message.getOwnerId())
+                    .viewed(false)
+                    .timestamp(LocalDateTime.now())
+                    .build();
+
+            notificationRepository.save(notification);
+            
+            log.info("Created notification for task deletion: task ID {}, recipient ID {}", 
+                    message.getTaskId(), message.getOwnerId());
+        } catch (Exception e) {
+            log.error("Failed to process task deleted event for task ID: {}", message.getTaskId(), e);
+            // Re-throw to trigger retry mechanism
+            throw e;
+        }
+    }
+}

--- a/src/main/java/org/example/taskmanager/messaging/TaskEventMessage.java
+++ b/src/main/java/org/example/taskmanager/messaging/TaskEventMessage.java
@@ -1,0 +1,71 @@
+package org.example.taskmanager.messaging;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TaskEventMessage {
+    
+    private Long taskId;
+    private String taskName;
+    private String taskDetails;
+    private Long ownerId;
+    private String ownerLogin;
+    private String ownerEmail;
+    private LocalDateTime createTime;
+    private LocalDateTime dueDate;
+    private String eventType; // CREATED, UPDATED, DELETED
+    private LocalDateTime eventTime;
+    
+    public static TaskEventMessage fromTaskCreated(org.example.taskmanager.domain.TaskEntity task, 
+                                                  String ownerLogin, String ownerEmail) {
+        return TaskEventMessage.builder()
+                .taskId(task.getId())
+                .taskName(task.getName())
+                .taskDetails(task.getDetails())
+                .ownerId(task.getOwnerId())
+                .ownerLogin(ownerLogin)
+                .ownerEmail(ownerEmail)
+                .createTime(task.getCreateTime())
+                .dueDate(task.getDueDate())
+                .eventType("CREATED")
+                .eventTime(LocalDateTime.now())
+                .build();
+    }
+    
+    public static TaskEventMessage fromTaskUpdated(org.example.taskmanager.domain.TaskEntity task, 
+                                                  String ownerLogin, String ownerEmail) {
+        return TaskEventMessage.builder()
+                .taskId(task.getId())
+                .taskName(task.getName())
+                .taskDetails(task.getDetails())
+                .ownerId(task.getOwnerId())
+                .ownerLogin(ownerLogin)
+                .ownerEmail(ownerEmail)
+                .createTime(task.getCreateTime())
+                .dueDate(task.getDueDate())
+                .eventType("UPDATED")
+                .eventTime(LocalDateTime.now())
+                .build();
+    }
+    
+    public static TaskEventMessage fromTaskDeleted(Long taskId, String taskName, Long ownerId, 
+                                                  String ownerLogin, String ownerEmail) {
+        return TaskEventMessage.builder()
+                .taskId(taskId)
+                .taskName(taskName)
+                .ownerId(ownerId)
+                .ownerLogin(ownerLogin)
+                .ownerEmail(ownerEmail)
+                .eventType("DELETED")
+                .eventTime(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/org/example/taskmanager/messaging/TaskEventPublisher.java
+++ b/src/main/java/org/example/taskmanager/messaging/TaskEventPublisher.java
@@ -1,0 +1,83 @@
+package org.example.taskmanager.messaging;
+
+import org.example.taskmanager.config.RabbitMQConfig;
+import org.example.taskmanager.domain.TaskEntity;
+import org.example.taskmanager.domain.UserEntity;
+import org.example.taskmanager.repository.UserDataRepository;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@ConditionalOnProperty(name = "spring.rabbitmq.host")
+@RequiredArgsConstructor
+@Slf4j
+public class TaskEventPublisher {
+
+    private final RabbitTemplate rabbitTemplate;
+    private final UserDataRepository userRepository;
+
+    public void publishTaskCreated(TaskEntity task) {
+        try {
+            UserEntity owner = userRepository.findById(task.getOwnerId())
+                    .orElseThrow(() -> new RuntimeException("User not found with id: " + task.getOwnerId()));
+            
+            TaskEventMessage message = TaskEventMessage.fromTaskCreated(task, owner.getLogin(), owner.getEmailAddress());
+            
+            rabbitTemplate.convertAndSend(
+                    RabbitMQConfig.TASK_EXCHANGE,
+                    RabbitMQConfig.TASK_CREATED_ROUTING_KEY,
+                    message
+            );
+            
+            log.info("Published task created event for task ID: {}, owner: {}", task.getId(), owner.getLogin());
+        } catch (Exception e) {
+            log.error("Failed to publish task created event for task ID: {}", task.getId(), e);
+            // Don't throw exception to avoid breaking the main flow
+        }
+    }
+
+    public void publishTaskUpdated(TaskEntity task) {
+        try {
+            UserEntity owner = userRepository.findById(task.getOwnerId())
+                    .orElseThrow(() -> new RuntimeException("User not found with id: " + task.getOwnerId()));
+            
+            TaskEventMessage message = TaskEventMessage.fromTaskUpdated(task, owner.getLogin(), owner.getEmailAddress());
+            
+            rabbitTemplate.convertAndSend(
+                    RabbitMQConfig.TASK_EXCHANGE,
+                    RabbitMQConfig.TASK_UPDATED_ROUTING_KEY,
+                    message
+            );
+            
+            log.info("Published task updated event for task ID: {}, owner: {}", task.getId(), owner.getLogin());
+        } catch (Exception e) {
+            log.error("Failed to publish task updated event for task ID: {}", task.getId(), e);
+            // Don't throw exception to avoid breaking the main flow
+        }
+    }
+
+    public void publishTaskDeleted(Long taskId, String taskName, Long ownerId) {
+        try {
+            UserEntity owner = userRepository.findById(ownerId)
+                    .orElseThrow(() -> new RuntimeException("User not found with id: " + ownerId));
+            
+            TaskEventMessage message = TaskEventMessage.fromTaskDeleted(taskId, taskName, ownerId, 
+                    owner.getLogin(), owner.getEmailAddress());
+            
+            rabbitTemplate.convertAndSend(
+                    RabbitMQConfig.TASK_EXCHANGE,
+                    RabbitMQConfig.TASK_DELETED_ROUTING_KEY,
+                    message
+            );
+            
+            log.info("Published task deleted event for task ID: {}, owner: {}", taskId, owner.getLogin());
+        } catch (Exception e) {
+            log.error("Failed to publish task deleted event for task ID: {}", taskId, e);
+            // Don't throw exception to avoid breaking the main flow
+        }
+    }
+}

--- a/src/main/java/org/example/taskmanager/repository/NotificationDataRepository.java
+++ b/src/main/java/org/example/taskmanager/repository/NotificationDataRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.example.taskmanager.domain.NotificationEntity;
 
 public interface NotificationDataRepository {
+    NotificationEntity save(NotificationEntity notification);
     List<NotificationEntity> findAllByRecipientId(Long recipientId);
     List<NotificationEntity> findPendingNotificationsByRecipientId(Long recipientId);
     List<NotificationEntity> findByRelatedTaskId(Long relatedTaskId);

--- a/src/main/java/org/example/taskmanager/repository/UserDataRepository.java
+++ b/src/main/java/org/example/taskmanager/repository/UserDataRepository.java
@@ -6,6 +6,7 @@ import org.example.taskmanager.domain.UserEntity;
 
 public interface UserDataRepository {
     UserEntity save(UserEntity user);
+    Optional<UserEntity> findById(Long id);
     Optional<UserEntity> findByLogin(String login);
     Optional<UserEntity> findByEmailAddress(String emailAddress);
     boolean existsByLogin(String login);

--- a/src/main/java/org/example/taskmanager/repository/jpa/impl/JpaNotificationRepository.java
+++ b/src/main/java/org/example/taskmanager/repository/jpa/impl/JpaNotificationRepository.java
@@ -32,4 +32,9 @@ public class JpaNotificationRepository implements NotificationDataRepository {
     public List<NotificationEntity> findByRelatedTaskId(Long relatedTaskId) {
         return jpaRepository.findByRelatedTaskId(relatedTaskId);
     }
+
+    @Override
+    public NotificationEntity save(NotificationEntity notification) {
+        return jpaRepository.save(notification);
+    }
 }

--- a/src/main/java/org/example/taskmanager/repository/jpa/impl/JpaNotificationRepositoryImpl.java
+++ b/src/main/java/org/example/taskmanager/repository/jpa/impl/JpaNotificationRepositoryImpl.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 @Repository
-@Profile({"docker", "postgresql"})
+@Profile({"docker", "postgresql", "messaging"})
 public class JpaNotificationRepositoryImpl implements NotificationDataRepository {
 
     private final NotificationJpaRepository jpaRepository;
@@ -31,5 +31,10 @@ public class JpaNotificationRepositoryImpl implements NotificationDataRepository
     @Override
     public List<NotificationEntity> findByRelatedTaskId(Long relatedTaskId) {
         return jpaRepository.findByRelatedTaskId(relatedTaskId);
+    }
+
+    @Override
+    public NotificationEntity save(NotificationEntity notification) {
+        return jpaRepository.save(notification);
     }
 }

--- a/src/main/java/org/example/taskmanager/repository/jpa/impl/JpaTaskRepositoryImpl.java
+++ b/src/main/java/org/example/taskmanager/repository/jpa/impl/JpaTaskRepositoryImpl.java
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 @Repository
-@Profile({"docker", "postgresql"})
+@Profile({"docker", "postgresql", "messaging"})
 public class JpaTaskRepositoryImpl implements TaskDataRepository {
 
     private final TaskJpaRepository jpaRepository;

--- a/src/main/java/org/example/taskmanager/repository/jpa/impl/JpaUserRepository.java
+++ b/src/main/java/org/example/taskmanager/repository/jpa/impl/JpaUserRepository.java
@@ -47,4 +47,9 @@ public class JpaUserRepository implements UserDataRepository {
     public boolean existsById(Long id) {
         return jpaRepository.existsById(id);
     }
+
+    @Override
+    public Optional<UserEntity> findById(Long id) {
+        return jpaRepository.findById(id);
+    }
 }

--- a/src/main/java/org/example/taskmanager/repository/jpa/impl/JpaUserRepositoryImpl.java
+++ b/src/main/java/org/example/taskmanager/repository/jpa/impl/JpaUserRepositoryImpl.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 @Repository
-@Profile({"docker", "postgresql"})
+@Profile({"docker", "postgresql", "messaging"})
 public class JpaUserRepositoryImpl implements UserDataRepository {
 
     private final UserJpaRepository jpaRepository;
@@ -46,5 +46,10 @@ public class JpaUserRepositoryImpl implements UserDataRepository {
     @Override
     public boolean existsById(Long id) {
         return jpaRepository.existsById(id);
+    }
+
+    @Override
+    public Optional<UserEntity> findById(Long id) {
+        return jpaRepository.findById(id);
     }
 }

--- a/src/main/java/org/example/taskmanager/repository/memory/MemoryNotificationRepository.java
+++ b/src/main/java/org/example/taskmanager/repository/memory/MemoryNotificationRepository.java
@@ -41,4 +41,13 @@ public class MemoryNotificationRepository implements NotificationDataRepository 
                 .filter(notification -> notification.getRelatedTaskId().equals(relatedTaskId))
                 .collect(Collectors.toList());
     }
+
+    @Override
+    public NotificationEntity save(NotificationEntity notification) {
+        if (notification.getId() == null) {
+            notification.setId(idGenerator.getAndIncrement());
+        }
+        storage.put(notification.getId(), notification);
+        return notification;
+    }
 }

--- a/src/main/java/org/example/taskmanager/repository/memory/MemoryUserRepository.java
+++ b/src/main/java/org/example/taskmanager/repository/memory/MemoryUserRepository.java
@@ -55,4 +55,9 @@ public class MemoryUserRepository implements UserDataRepository {
     public boolean existsById(Long id) {
         return storage.containsKey(id);
     }
+
+    @Override
+    public Optional<UserEntity> findById(Long id) {
+        return Optional.ofNullable(storage.get(id));
+    }
 }

--- a/src/main/java/org/example/taskmanager/service/TaskManagementService.java
+++ b/src/main/java/org/example/taskmanager/service/TaskManagementService.java
@@ -5,8 +5,10 @@ import java.util.List;
 
 import org.example.taskmanager.domain.TaskEntity;
 import org.example.taskmanager.exception.EntityNotFoundException;
+import org.example.taskmanager.messaging.TaskEventPublisher;
 import org.example.taskmanager.repository.TaskDataRepository;
 import org.example.taskmanager.repository.UserDataRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -19,6 +21,9 @@ public class TaskManagementService {
 
     private final TaskDataRepository taskRepository;
     private final UserDataRepository userRepository;
+    
+    @Autowired(required = false)
+    private TaskEventPublisher taskEventPublisher;
 
     @Cacheable(value = "tasks", key = "'all-tasks-' + #ownerId")
     public List<TaskEntity> getAllUserTasks(Long ownerId) {
@@ -40,15 +45,32 @@ public class TaskManagementService {
     public TaskEntity addNewTask(TaskEntity task) {
         performTaskValidation(task);
         task.setCreateTime(LocalDateTime.now());
-        return taskRepository.save(task);
+        TaskEntity savedTask = taskRepository.save(task);
+        
+        // Publish task created event
+        if (taskEventPublisher != null) {
+            taskEventPublisher.publishTaskCreated(savedTask);
+        }
+        
+        return savedTask;
     }
 
     @CacheEvict(value = "tasks", allEntries = true)
     public void removeTask(Long taskId, Long ownerId) {
         TaskEntity task = taskRepository.findByIdAndOwnerId(taskId, ownerId)
                 .orElseThrow(() -> new EntityNotFoundException("Task with id " + taskId + " not found"));
+        
+        // Store task info before marking as removed
+        String taskName = task.getName();
+        Long taskOwnerId = task.getOwnerId();
+        
         task.setRemoved(true);
         taskRepository.save(task);
+        
+        // Publish task deleted event
+        if (taskEventPublisher != null) {
+            taskEventPublisher.publishTaskDeleted(taskId, taskName, taskOwnerId);
+        }
     }
 
     private void performTaskValidation(TaskEntity task) {

--- a/src/test/java/org/example/taskmanager/integration/MessagingProfileIntegrationTest.java
+++ b/src/test/java/org/example/taskmanager/integration/MessagingProfileIntegrationTest.java
@@ -1,0 +1,90 @@
+package org.example.taskmanager.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.example.taskmanager.domain.TaskEntity;
+import org.example.taskmanager.domain.UserEntity;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("messaging")
+class MessagingProfileIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    private String getBaseUrl() {
+        return "http://localhost:" + port;
+    }
+
+    @Test
+    void shouldCreateTaskAndTriggerNotificationViaMessaging() {
+        // Given - create user first
+        String uniqueId = String.valueOf(System.currentTimeMillis());
+        UserEntity user = UserEntity.builder()
+                .login("messaginguser" + uniqueId)
+                .emailAddress("messaging" + uniqueId + "@example.com")
+                .passwordHash("password123")
+                .build();
+
+        HttpEntity<UserEntity> userRequest = new HttpEntity<>(user);
+        ResponseEntity<String> userResponse = restTemplate.exchange(
+                getBaseUrl() + "/api/users/register",
+                HttpMethod.POST,
+                userRequest,
+                String.class
+        );
+        assertThat(userResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        // Create task
+        TaskEntity task = TaskEntity.builder()
+                .name("Messaging Test Task")
+                .details("This task should trigger notification via messaging")
+                .ownerId(1L)
+                .dueDate(java.time.LocalDateTime.of(2025, 12, 31, 23, 59, 59))
+                .build();
+
+        HttpEntity<TaskEntity> taskRequest = new HttpEntity<>(task);
+
+        // When - create task (should trigger message and create notification)
+        ResponseEntity<String> taskResponse = restTemplate.exchange(
+                getBaseUrl() + "/api/tasks",
+                HttpMethod.POST,
+                taskRequest,
+                String.class
+        );
+
+        // Then
+        assertThat(taskResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(taskResponse.getBody()).contains("Messaging Test Task");
+
+        // Wait a bit for async message processing
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        // Check that notification was created via messaging
+        ResponseEntity<String> notificationsResponse = restTemplate.exchange(
+                getBaseUrl() + "/api/notifications/1",
+                HttpMethod.GET,
+                null,
+                String.class
+        );
+
+        assertThat(notificationsResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(notificationsResponse.getBody()).contains("New task created: Messaging Test Task");
+    }
+}

--- a/src/test/java/org/example/taskmanager/messaging/TaskEventListenerTest.java
+++ b/src/test/java/org/example/taskmanager/messaging/TaskEventListenerTest.java
@@ -1,0 +1,112 @@
+package org.example.taskmanager.messaging;
+
+import org.example.taskmanager.domain.NotificationEntity;
+import org.example.taskmanager.repository.NotificationDataRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TaskEventListenerTest {
+
+    @Mock
+    private NotificationDataRepository notificationRepository;
+
+    @InjectMocks
+    private TaskEventListener taskEventListener;
+
+    private TaskEventMessage testMessage;
+
+    @BeforeEach
+    void setUp() {
+        testMessage = TaskEventMessage.builder()
+                .taskId(1L)
+                .taskName("Test Task")
+                .taskDetails("Test task details")
+                .ownerId(1L)
+                .ownerLogin("testuser")
+                .ownerEmail("test@example.com")
+                .createTime(LocalDateTime.now())
+                .dueDate(LocalDateTime.now().plusDays(1))
+                .eventType("CREATED")
+                .eventTime(LocalDateTime.now())
+                .build();
+    }
+
+    @Test
+    void shouldHandleTaskCreatedEvent() {
+        // When
+        taskEventListener.handleTaskCreated(testMessage);
+
+        // Then
+        verify(notificationRepository).save(any(NotificationEntity.class));
+    }
+
+    @Test
+    void shouldHandleTaskUpdatedEvent() {
+        // When
+        taskEventListener.handleTaskUpdated(testMessage);
+
+        // Then
+        verify(notificationRepository).save(any(NotificationEntity.class));
+    }
+
+    @Test
+    void shouldHandleTaskDeletedEvent() {
+        // When
+        taskEventListener.handleTaskDeleted(testMessage);
+
+        // Then
+        verify(notificationRepository).save(any(NotificationEntity.class));
+    }
+
+    @Test
+    void shouldCreateCorrectNotificationForTaskCreated() {
+        // When
+        taskEventListener.handleTaskCreated(testMessage);
+
+        // Then
+        verify(notificationRepository).save(argThat(notification -> 
+                notification.getMessage().equals("New task created: Test Task") &&
+                notification.getRelatedTaskId().equals(1L) &&
+                notification.getRecipientId().equals(1L) &&
+                !notification.getViewed()
+        ));
+    }
+
+    @Test
+    void shouldCreateCorrectNotificationForTaskUpdated() {
+        // When
+        taskEventListener.handleTaskUpdated(testMessage);
+
+        // Then
+        verify(notificationRepository).save(argThat(notification -> 
+                notification.getMessage().equals("Task updated: Test Task") &&
+                notification.getRelatedTaskId().equals(1L) &&
+                notification.getRecipientId().equals(1L) &&
+                !notification.getViewed()
+        ));
+    }
+
+    @Test
+    void shouldCreateCorrectNotificationForTaskDeleted() {
+        // When
+        taskEventListener.handleTaskDeleted(testMessage);
+
+        // Then
+        verify(notificationRepository).save(argThat(notification -> 
+                notification.getMessage().equals("Task deleted: Test Task") &&
+                notification.getRelatedTaskId().equals(1L) &&
+                notification.getRecipientId().equals(1L) &&
+                !notification.getViewed()
+        ));
+    }
+}

--- a/src/test/java/org/example/taskmanager/messaging/TaskEventPublisherTest.java
+++ b/src/test/java/org/example/taskmanager/messaging/TaskEventPublisherTest.java
@@ -1,0 +1,117 @@
+package org.example.taskmanager.messaging;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.example.taskmanager.domain.TaskEntity;
+import org.example.taskmanager.domain.UserEntity;
+import org.example.taskmanager.repository.UserDataRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class TaskEventPublisherTest {
+
+    @Mock
+    private RabbitTemplate rabbitTemplate;
+
+    @Mock
+    private UserDataRepository userRepository;
+
+    @InjectMocks
+    private TaskEventPublisher taskEventPublisher;
+
+    private TaskEntity testTask;
+    private UserEntity testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = UserEntity.builder()
+                .id(1L)
+                .login("testuser")
+                .emailAddress("test@example.com")
+                .passwordHash("password123")
+                .build();
+
+        testTask = TaskEntity.builder()
+                .id(1L)
+                .name("Test Task")
+                .details("Test task details")
+                .ownerId(1L)
+                .createTime(LocalDateTime.now())
+                .dueDate(LocalDateTime.now().plusDays(1))
+                .removed(false)
+                .build();
+    }
+
+    @Test
+    void shouldPublishTaskCreatedEvent() {
+        // Given
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+
+        // When
+        taskEventPublisher.publishTaskCreated(testTask);
+
+        // Then
+        verify(rabbitTemplate).convertAndSend(
+                eq("task.exchange"),
+                eq("task.created"),
+                any(TaskEventMessage.class)
+        );
+    }
+
+    @Test
+    void shouldPublishTaskUpdatedEvent() {
+        // Given
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+
+        // When
+        taskEventPublisher.publishTaskUpdated(testTask);
+
+        // Then
+        verify(rabbitTemplate).convertAndSend(
+                eq("task.exchange"),
+                eq("task.updated"),
+                any(TaskEventMessage.class)
+        );
+    }
+
+    @Test
+    void shouldPublishTaskDeletedEvent() {
+        // Given
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+
+        // When
+        taskEventPublisher.publishTaskDeleted(1L, "Test Task", 1L);
+
+        // Then
+        verify(rabbitTemplate).convertAndSend(
+                eq("task.exchange"),
+                eq("task.deleted"),
+                any(TaskEventMessage.class)
+        );
+    }
+
+    @Test
+    void shouldHandleUserNotFoundGracefully() {
+        // Given
+        when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // When
+        taskEventPublisher.publishTaskCreated(testTask);
+
+        // Then
+        verify(rabbitTemplate, never()).convertAndSend(anyString(), anyString(), any(Object.class));
+    }
+}


### PR DESCRIPTION
- Add RabbitMQ service to Docker Compose with health checks
- Create TaskEventPublisher to publish task creation/deletion events
- Implement TaskEventListener for async message processing
- Add TopicExchange with routing keys for flexible message routing
- Configure conditional RabbitMQ beans with @ConditionalOnProperty
- Create messaging profile with application-messaging.properties
- Add unit tests for TaskEventPublisher and TaskEventListener
- Update TaskManagementService to use optional TaskEventPublisher
- Add comprehensive Step 7 report to README.md
- Support all profiles: inmemory, h2, docker, postgresql, cache, messaging